### PR TITLE
feat(auth): block --public --no-password unsafe configuration

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -230,7 +230,7 @@ function parseArgs() {
   let useTunnel = true;
   let noTunnel = false;
   let persistedTunnel = false;
-  let anonymousTunnel = false;
+  let publicTunnel = false;
   let explicitPassword = !!password;
 
   const args = process.argv.slice(2);
@@ -248,7 +248,7 @@ function parseArgs() {
       useTunnel = true;
       persistedTunnel = true;
     } else if (args[i] === '--public') {
-      anonymousTunnel = true;
+      publicTunnel = true;
     } else if (args[i].startsWith('--password=')) {
       password = args[i].split('=')[1];
       explicitPassword = true;
@@ -285,8 +285,22 @@ function parseArgs() {
   if (noTunnel) useTunnel = false;
 
   // --public requires a tunnel
-  if (anonymousTunnel && !useTunnel) {
-    console.error('Error: --public requires a tunnel. Remove --no-tunnel or remove --public.');
+  if (publicTunnel && !useTunnel) {
+    const rd = '\x1b[31m';
+    const rs = '\x1b[0m';
+    console.error(
+      `${rd}Error: --public requires a tunnel. Remove --no-tunnel or remove --public.${rs}`,
+    );
+    process.exit(1);
+  }
+
+  // --public requires password authentication
+  if (publicTunnel && !password) {
+    const rd = '\x1b[31m';
+    const rs = '\x1b[0m';
+    console.error(
+      `${rd}Error: Public tunnels require password authentication. Remove --no-password or remove --public.${rs}`,
+    );
     process.exit(1);
   }
 
@@ -302,7 +316,7 @@ function parseArgs() {
     password,
     useTunnel,
     persistedTunnel,
-    anonymousTunnel,
+    publicTunnel,
     shell,
     shellArgs,
     cwd,

--- a/src/server.js
+++ b/src/server.js
@@ -27,10 +27,10 @@ function getLocalIP() {
   return '127.0.0.1';
 }
 
-function confirmAnonymousTunnel() {
+function confirmPublicTunnel() {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   return new Promise((resolve) => {
-    rl.question('  Do you want to continue with anonymous access? (y/N): ', (answer) => {
+    rl.question('  Do you want to continue with public access? (y/N): ', (answer) => {
       rl.close();
       resolve(answer.trim().toLowerCase() === 'y');
     });
@@ -110,8 +110,8 @@ function createTermBeamServer(overrides = {}) {
       }
     }
 
-    // Warn and require consent for anonymous tunnel access
-    if (config.useTunnel && config.anonymousTunnel) {
+    // Warn and require consent for public tunnel access
+    if (config.useTunnel && config.publicTunnel) {
       const rd = '\x1b[31m';
       const yl = '\x1b[33m';
       const rs = '\x1b[0m';
@@ -123,7 +123,7 @@ function createTermBeamServer(overrides = {}) {
       console.log(`  ${yl}No Microsoft login will be required to reach the tunnel.${rs}`);
       console.log(`  ${yl}Only the TermBeam password will protect your terminal.${rs}`);
       console.log('');
-      const confirmed = await confirmAnonymousTunnel();
+      const confirmed = await confirmPublicTunnel();
       if (!confirmed) {
         console.log('');
         console.log('  Aborted. Restart without --public for private access.');
@@ -178,7 +178,7 @@ function createTermBeamServer(overrides = {}) {
         if (config.useTunnel) {
           const tunnel = await startTunnel(config.port, {
             persisted: config.persistedTunnel,
-            anonymous: config.anonymousTunnel,
+            anonymous: config.publicTunnel,
           });
           if (tunnel) {
             publicUrl = tunnel.url;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -310,6 +310,63 @@ describe('CLI', () => {
     }
   });
 
+  it('--public --no-password should exit with error', () => {
+    process.argv = ['node', 'termbeam', '--public', '--no-password'];
+    const exitCalls = [];
+    const errorMessages = [];
+    const origExit = process.exit;
+    const origError = console.error;
+    process.exit = (code) => exitCalls.push(code);
+    console.error = (msg) => errorMessages.push(msg);
+    try {
+      const { parseArgs } = require('../src/cli');
+      parseArgs();
+      assert.ok(exitCalls.includes(1), 'Should call process.exit(1)');
+      assert.ok(
+        errorMessages.some((m) => m.includes('Public tunnels require password')),
+        'Should mention public tunnels require password',
+      );
+    } finally {
+      process.exit = origExit;
+      console.error = origError;
+    }
+  });
+
+  it('--public with password should work without error', () => {
+    process.argv = ['node', 'termbeam', '--public', '--password', 'secret'];
+    const exitCalls = [];
+    const origExit = process.exit;
+    process.exit = (code) => exitCalls.push(code);
+    try {
+      const { parseArgs } = require('../src/cli');
+      const config = parseArgs();
+      assert.strictEqual(config.publicTunnel, true);
+      assert.strictEqual(config.password, 'secret');
+      assert.ok(!exitCalls.includes(1), 'Should not exit with error when password is provided');
+    } finally {
+      process.exit = origExit;
+    }
+  });
+
+  it('--public with auto-generated password should work without error', () => {
+    process.argv = ['node', 'termbeam', '--public'];
+    const exitCalls = [];
+    const origExit = process.exit;
+    process.exit = (code) => exitCalls.push(code);
+    try {
+      const { parseArgs } = require('../src/cli');
+      const config = parseArgs();
+      assert.strictEqual(config.publicTunnel, true);
+      assert.ok(config.password, 'Should have auto-generated password');
+      assert.ok(
+        !exitCalls.includes(1),
+        'Should not exit with error when password is auto-generated',
+      );
+    } finally {
+      process.exit = origExit;
+    }
+  });
+
   describe('isKnownShell', () => {
     it('should recognize common shells', () => {
       const { isKnownShell } = require('../src/cli');


### PR DESCRIPTION
## Summary

Adds a hard guardrail that prevents starting TermBeam with `--public` and `--no-password` simultaneously, which would expose an unauthenticated terminal to the internet.

## Changes

- **`src/cli.js`**: Added validation in `parseArgs()` that exits with a clear error when `--public` is used without password authentication
- **`test/cli.test.js`**: Added 3 tests:
  - `--public --no-password` exits with error and clear message
  - `--public --password secret` works correctly (no false positive)
  - `--public` with auto-generated password works correctly (no false positive)

## Error Message

```
Error: Public tunnels require password authentication. Remove --no-password or remove --public.
```

Closes #34