### PR TITLE
feat(auth): set cookie Secure flag dynamically based on HTTPS

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -23,7 +23,7 @@ TermBeam is designed for **trusted local networks**. It is NOT designed as a pro
 - Session IDs use 128-bit entropy (`crypto.randomBytes(16)`, hex-encoded)
 - Stored in httpOnly cookies (not accessible via JavaScript)
 - Cookie uses `sameSite: lax` to prevent CSRF
-- Cookie `secure` flag is off for HTTP compatibility (tunnels use TLS at the proxy layer)
+- Cookie `Secure` flag is set dynamically based on the request protocol — enabled automatically when accessed over HTTPS (including via `X-Forwarded-Proto` from tunnel proxies), omitted for plain HTTP
 
 ### QR Code & Share Auto-Login (Share Tokens)
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -28,7 +28,7 @@ function setupRoutes(app, { auth, sessions, config, state }) {
         httpOnly: true,
         sameSite: 'lax',
         maxAge: 24 * 60 * 60 * 1000,
-        secure: false,
+        secure: req.secure,
       });
       log.info(`Auth: login success from ${req.ip}`);
       res.json({ ok: true });
@@ -58,7 +58,7 @@ function setupRoutes(app, { auth, sessions, config, state }) {
         httpOnly: true,
         sameSite: 'lax',
         maxAge: 24 * 60 * 60 * 1000,
-        secure: false,
+        secure: req.secure,
       });
       log.info(`Auth: share-token auto-login from ${req.ip}`);
       // Redirect to the same path without ?ott= to keep the URL clean

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -440,6 +440,76 @@ describe('Routes', () => {
     });
   });
 
+  // === Cookie Secure flag ===
+  describe('cookie Secure flag', () => {
+    let inst;
+    after(() => inst?.shutdown());
+
+    it('POST /api/auth should set Secure cookie when X-Forwarded-Proto is https', async () => {
+      inst = await startServer({ password: 'secret' });
+      const body = JSON.stringify({ password: 'secret' });
+      const res = await httpRequest(
+        {
+          hostname: '127.0.0.1',
+          port: inst.port,
+          path: '/api/auth',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body),
+            'X-Forwarded-Proto': 'https',
+          },
+        },
+        body,
+      );
+      assert.strictEqual(res.statusCode, 200);
+      const cookies = res.headers['set-cookie'] || [];
+      const ptyCookie = cookies.find((c) => c.startsWith('pty_token='));
+      assert.ok(ptyCookie, 'Should set pty_token cookie');
+      assert.ok(/;\s*Secure/i.test(ptyCookie), 'Cookie should include Secure flag');
+    });
+
+    it('POST /api/auth should NOT set Secure cookie over plain HTTP', async () => {
+      if (!inst) inst = await startServer({ password: 'secret' });
+      const body = JSON.stringify({ password: 'secret' });
+      const res = await httpRequest(
+        {
+          hostname: '127.0.0.1',
+          port: inst.port,
+          path: '/api/auth',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body),
+          },
+        },
+        body,
+      );
+      assert.strictEqual(res.statusCode, 200);
+      const cookies = res.headers['set-cookie'] || [];
+      const ptyCookie = cookies.find((c) => c.startsWith('pty_token='));
+      assert.ok(ptyCookie, 'Should set pty_token cookie');
+      assert.ok(!/;\s*Secure/i.test(ptyCookie), 'Cookie should NOT include Secure flag');
+    });
+
+    it('GET /?ott=<valid> should set Secure cookie when X-Forwarded-Proto is https', async () => {
+      if (!inst) inst = await startServer({ password: 'secret' });
+      const ott = inst.auth.generateShareToken();
+      const res = await httpRequest({
+        hostname: '127.0.0.1',
+        port: inst.port,
+        path: `/?ott=${ott}`,
+        method: 'GET',
+        headers: { 'X-Forwarded-Proto': 'https' },
+      });
+      assert.strictEqual(res.statusCode, 302);
+      const cookies = res.headers['set-cookie'] || [];
+      const ptyCookie = cookies.find((c) => c.startsWith('pty_token='));
+      assert.ok(ptyCookie, 'Should set pty_token cookie');
+      assert.ok(/;\s*Secure/i.test(ptyCookie), 'Cookie should include Secure flag');
+    });
+  });
+
   // === Share token endpoint ===
   describe('GET /api/share-token', () => {
     let inst;


### PR DESCRIPTION
## Summary

Cookies now include the `Secure` flag when the request is over HTTPS (or `X-Forwarded-Proto: https`). Previously `secure: false` was hardcoded, meaning auth cookies could be sent over insecure connections even when accessed via DevTunnels (HTTPS).

## Changes

- **`src/routes.js`**: Changed `secure: false` → `secure: req.secure` in both cookie-setting locations (POST `/api/auth` and `autoLogin`)
- **`test/routes.test.js`**: Added 3 tests:
  - `Set-Cookie` includes `Secure` when `X-Forwarded-Proto: https`
  - `Set-Cookie` does NOT include `Secure` over plain HTTP
  - Share-token auto-login sets `Secure` over HTTPS
- **`docs/security.md`**: Updated cookie documentation to reflect dynamic Secure flag

## Design

Uses Express's built-in `req.secure` which returns `true` when the connection is HTTPS (including via `X-Forwarded-Proto` since `trust proxy` is already set to `'loopback'` in `server.js`).

Closes #36