### PR TITLE
feat(cli): change default bind from 0.0.0.0 to 127.0.0.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,6 +96,7 @@ These are intentional design choices — not bugs:
 - **Cookie `secure` flag is off** — TermBeam runs over HTTP locally; TLS is handled at the tunnel proxy layer (DevTunnels). Setting `secure` would break cookie auth on LAN.
 - **Password compared in constant time?** No — the password is short-lived and auto-generated; rate limiting (5 attempts/min/IP) is the primary brute-force defense.
 - **Tunnel is on by default** — makes the tool useful out of the box (phone on cellular), but this means the terminal is internet-accessible. Password auto-generation compensates.
+- **Default bind is `127.0.0.1`** — localhost only by default. Use `--lan` or `--host 0.0.0.0` for LAN access.
 - **`--no-password` exists** — for trusted localhost-only scenarios. Never combine with tunnel.
 - **Session IDs are 128-bit random** (`crypto.randomBytes(16)`) — unguessable, but not secret (visible in URLs). Auth tokens protect access, not session IDs.
 - **WebSocket origin validation** — cross-origin connections are rejected (close code 1008) unless one side is localhost, preventing malicious websites from connecting to a local instance.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Persisted tunnels save a tunnel ID to `~/.termbeam/tunnel.json` so the URL stays
 ```bash
 termbeam [shell] [args...]        # start with a specific shell (default: auto-detect)
 termbeam --port 8080              # custom port (default: 3456)
-termbeam --host 127.0.0.1        # restrict to localhost (default: 0.0.0.0)
+termbeam --host 0.0.0.0           # allow LAN access (default: 127.0.0.1)
+termbeam --lan                    # shortcut for --host 0.0.0.0
 ```
 
 | Flag                  | Description                                          | Default        |
@@ -117,14 +118,15 @@ termbeam --host 127.0.0.1        # restrict to localhost (default: 0.0.0.0)
 | `--persisted-tunnel`  | Create a reusable devtunnel URL                      | Off            |
 | `--public`            | Allow public tunnel access                           | Off            |
 | `--port <port>`       | Server port                                          | `3456`         |
-| `--host <addr>`       | Bind address                                         | `0.0.0.0`      |
+| `--host <addr>`       | Bind address                                         | `127.0.0.1`    |
+| `--lan`               | Bind to all interfaces (LAN access)                  | Off            |
 | `--log-level <level>` | Log verbosity (error/warn/info/debug)                | `info`         |
 
 Environment variables: `PORT`, `TERMBEAM_PASSWORD`, `TERMBEAM_CWD`, `TERMBEAM_LOG_LEVEL`, `SHELL` (Unix fallback), `COMSPEC` (Windows fallback). See [Configuration docs](https://dorlugasigal.github.io/TermBeam/configuration/).
 
 ## Security
 
-TermBeam auto-generates a password and creates a tunnel by default, so your terminal is protected out of the box. Be aware that the tunnel exposes your terminal to the internet — use `--no-tunnel` for LAN-only access, or `--host 127.0.0.1` to restrict to your machine only.
+TermBeam auto-generates a password and creates a tunnel by default, so your terminal is protected out of the box. By default, the server binds to `127.0.0.1` (localhost only). Use `--lan` or `--host 0.0.0.0` to allow LAN access, or `--no-tunnel` to disable the tunnel.
 
 Auth uses secure httpOnly cookies with 24-hour expiry, login is rate-limited to 5 attempts per minute, and security headers (X-Frame-Options, X-Content-Type-Options, etc.) are set on all responses. The QR code on startup embeds a share token for password-free login — the token is reusable within its 5-minute validity window, which handles tunnel proxy retries and link preview services. API clients that can't use cookies can authenticate with an `Authorization: Bearer <password>` header. See the [Security Guide](https://dorlugasigal.github.io/TermBeam/security/) for more.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,8 @@ description: All TermBeam CLI flags and options — ports, passwords, tunnels, s
 | `--persisted-tunnel`  | Create a reusable devtunnel URL (stable across restarts)         | Off       |
 | `--public`            | Allow public tunnel access (no Microsoft login required)         | Off       |
 | `--port <port>`       | Server port                                                      | `3456`    |
-| `--host <addr>`       | Bind address                                                     | `0.0.0.0` |
+| `--host <addr>`       | Bind address                                                     | `127.0.0.1` |
+| `--lan`               | Bind to all interfaces (LAN access)                              | Off       |
 | `-h, --help`          | Show help                                                        | —         |
 | `-v, --version`       | Show version                                                     | —         |
 | `--log-level <level>` | Set log verbosity: `error`, `warn`, `info`, `debug`              | `info`    |
@@ -75,12 +76,17 @@ TERMBEAM_PASSWORD=mysecret termbeam
 
 ### Network Access
 
+By default, TermBeam binds to localhost only. Use `--lan` or `--host 0.0.0.0` to allow connections from other devices on your network.
+
 ```bash
-# Listen on all interfaces with auto-generated password (default behavior)
+# Localhost only (default behavior)
 termbeam
 
-# Localhost only, no tunnel
-termbeam --no-tunnel --host 127.0.0.1
+# Allow LAN access
+termbeam --lan
+
+# Allow LAN access (equivalent to --lan)
+termbeam --host 0.0.0.0
 
 # Create a public tunnel (internet access) — on by default
 termbeam

--- a/docs/security.md
+++ b/docs/security.md
@@ -66,8 +66,8 @@ Every response includes:
 
 ### Network Binding
 
-- **Default:** Binds to `0.0.0.0` (all interfaces, LAN-accessible)
-- Use `--host 127.0.0.1` to restrict to localhost only
+- **Default:** Binds to `127.0.0.1` (localhost only)
+- Use `--lan` or `--host 0.0.0.0` to allow LAN access
 - The tunnel feature handles TLS via Azure DevTunnels
 
 ## Best Practices
@@ -76,7 +76,7 @@ Every response includes:
 Without authentication, anyone on the network can access your terminal with your user permissions.
 
 1. **Password is on by default** — use `--no-password` only for trusted localhost scenarios. `--public` requires password authentication and will refuse to start without it
-2. **Use `--host 127.0.0.1`** if you don't need LAN access
+2. **Localhost is the default** — use `--lan` only when you need LAN access
 3. **Tunnel access is private by default** — only you (the tunnel owner) can access it via Microsoft login. Use `--public` to allow public access, or `--no-tunnel` for LAN-only mode
 4. **Close TermBeam when done** — it's not a daemon, don't leave it running
 5. **Use on trusted networks** — TermBeam is not designed for hostile environments

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,7 +20,8 @@ Options:
   --persisted-tunnel    Create a reusable devtunnel URL (stable across restarts)
   --public              Allow public tunnel access (default: private, owner-only)
   --port <port>         Set port (default: 3456, or PORT env var)
-  --host <addr>         Bind address (default: 0.0.0.0)
+  --host <addr>         Bind address (default: 127.0.0.1)
+  --lan                 Bind to 0.0.0.0 (allow LAN access, default: localhost only)
   --log-level <level>   Set log verbosity: error, warn, info, debug (default: info)
   -h, --help            Show this help
   -v, --version         Show version
@@ -206,7 +207,7 @@ function getDefaultShell() {
 
 function parseArgs() {
   let port = parseInt(process.env.PORT || '3456', 10);
-  let host = '0.0.0.0';
+  let host = '127.0.0.1';
 
   // Resolve log level early (env + args) so shell detection logs are visible
   let logLevel = process.env.TERMBEAM_LOG_LEVEL || 'info';
@@ -267,6 +268,8 @@ function parseArgs() {
       explicitPassword = true;
     } else if (args[i] === '--port' && args[i + 1]) {
       port = parseInt(args[++i], 10);
+    } else if (args[i] === '--lan') {
+      host = '0.0.0.0';
     } else if (args[i] === '--host' && args[i + 1]) {
       host = args[++i];
     } else if (args[i] === '--log-level' && args[i + 1]) {

--- a/src/server.js
+++ b/src/server.js
@@ -191,10 +191,16 @@ function createTermBeamServer(overrides = {}) {
         console.log(`  Shell:    ${config.shell}`);
         console.log(`  Session:  ${defaultId}`);
         console.log(`  Auth:     ${config.password ? `${gn}🔒 password${rs}` : '🔓 none'}`);
+        if (isLanReachable) {
+          console.log(`  Bind:     ${config.host} (LAN accessible)`);
+        } else {
+          console.log(`  Bind:     ${config.host} (localhost only)`);
+        }
         console.log('');
 
         if (publicUrl) {
-          console.log(`  🌐 Public:  ${publicUrl}`);
+          const bl = '\x1b[34m'; // blue
+          console.log(`  Public:   ${bl}${publicUrl}${rs}`);
         }
         console.log(`  Local:    http://localhost:${config.port}`);
         if (isLanReachable) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -28,7 +28,7 @@ describe('CLI', () => {
     const { parseArgs } = require('../src/cli');
     const config = parseArgs();
     assert.strictEqual(config.port, 3456);
-    assert.strictEqual(config.host, '0.0.0.0');
+    assert.strictEqual(config.host, '127.0.0.1');
     assert.ok(config.password, 'should auto-generate password by default');
     assert.ok(config.password.length > 10, 'auto-generated password should be long');
     assert.strictEqual(config.useTunnel, true);
@@ -234,6 +234,20 @@ describe('CLI', () => {
     const { parseArgs } = require('../src/cli');
     const config = parseArgs();
     assert.strictEqual(config.password, 'flagpw');
+  });
+
+  it('should parse --lan flag', () => {
+    process.argv = ['node', 'termbeam', '--lan'];
+    const { parseArgs } = require('../src/cli');
+    const config = parseArgs();
+    assert.strictEqual(config.host, '0.0.0.0');
+  });
+
+  it('--host should override --lan', () => {
+    process.argv = ['node', 'termbeam', '--lan', '--host', '192.168.1.1'];
+    const { parseArgs } = require('../src/cli');
+    const config = parseArgs();
+    assert.strictEqual(config.host, '192.168.1.1');
   });
 
   it('should parse --no-tunnel flag', () => {


### PR DESCRIPTION
## Summary

Changes the default host binding from `0.0.0.0` to `127.0.0.1`, reducing default attack surface. Adds `--lan` flag for convenient LAN access opt-in.

## Changes
- Default host: `127.0.0.1` (was `0.0.0.0`)
- New `--lan` flag (shortcut for `--host 0.0.0.0`)
- Startup output indicates bind mode (localhost only vs LAN accessible)
- README, docs/configuration.md, docs/security.md updated
- Tests updated + new tests for `--lan` flag

**Breaking change:** Users relying on LAN access without `--host` must now use `--lan` or `--host 0.0.0.0`. Tunnel-based remote access is unaffected.

Closes #37