### PR TITLE
fix(auth): consistent auth responses for API vs UI routes

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -24,6 +24,7 @@ TermBeam is designed for **trusted local networks**. It is NOT designed as a pro
 - Stored in httpOnly cookies (not accessible via JavaScript)
 - Cookie uses `sameSite: lax` to prevent CSRF
 - Cookie `Secure` flag is set dynamically based on the request protocol — enabled automatically when accessed over HTTPS (including via `X-Forwarded-Proto` from tunnel proxies), omitted for plain HTTP
+- API routes (`/api/*`) always return JSON `401`/`429` responses. UI routes redirect to the login page.
 
 ### QR Code & Share Auto-Login (Share Tokens)
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -145,8 +145,8 @@ function createAuth(password) {
       authAttempts.set(ip, recent);
       return res.status(401).json({ error: 'unauthorized' });
     }
-    if (req.accepts('html')) return res.redirect('/login');
-    res.status(401).json({ error: 'unauthorized' });
+    if (req.path.startsWith('/api/')) return res.status(401).json({ error: 'unauthorized' });
+    res.redirect('/login');
   }
 
   function rateLimit(req, res, next) {

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -71,7 +71,7 @@ describe('Auth', () => {
       const auth = createAuth('secret');
       let statusCode = null;
       let jsonBody = null;
-      const req = { cookies: {}, headers: {}, accepts: () => false };
+      const req = { cookies: {}, headers: {}, accepts: () => false, path: '/api/sessions' };
       const res = {
         status(code) {
           statusCode = code;
@@ -84,12 +84,54 @@ describe('Auth', () => {
       };
       auth.middleware(req, res, () => {});
       assert.strictEqual(statusCode, 401);
+      assert.deepStrictEqual(jsonBody, { error: 'unauthorized' });
     });
 
-    it('should redirect to /login when accepts html', () => {
+    it('should redirect to /login for non-API paths', () => {
       const auth = createAuth('secret');
       let redirectPath = null;
-      const req = { cookies: {}, headers: {}, accepts: () => true };
+      const req = { cookies: {}, headers: {}, accepts: () => true, path: '/terminal' };
+      const res = {
+        redirect(path) {
+          redirectPath = path;
+        },
+        status() {
+          return this;
+        },
+        json() {},
+      };
+      auth.middleware(req, res, () => {});
+      assert.strictEqual(redirectPath, '/login');
+    });
+
+    it('should return JSON 401 for /api/* routes regardless of Accept header', () => {
+      const auth = createAuth('secret');
+      let statusCode = null;
+      let jsonBody = null;
+      let redirectPath = null;
+      const req = { cookies: {}, headers: {}, accepts: () => true, path: '/api/sessions' };
+      const res = {
+        status(code) {
+          statusCode = code;
+          return this;
+        },
+        json(body) {
+          jsonBody = body;
+        },
+        redirect(path) {
+          redirectPath = path;
+        },
+      };
+      auth.middleware(req, res, () => {});
+      assert.strictEqual(statusCode, 401);
+      assert.deepStrictEqual(jsonBody, { error: 'unauthorized' });
+      assert.strictEqual(redirectPath, null);
+    });
+
+    it('should redirect non-API routes to /login', () => {
+      const auth = createAuth('secret');
+      let redirectPath = null;
+      const req = { cookies: {}, headers: {}, accepts: () => false, path: '/terminal' };
       const res = {
         redirect(path) {
           redirectPath = path;

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -344,6 +344,21 @@ describe('Routes', () => {
       assert.ok(res.headers.location === '/' || res.headers.location.includes('/'));
     });
 
+    it('GET /api/sessions without auth should return 401 JSON', async () => {
+      inst?.shutdown();
+      inst = await startServer({ password: 'secret123' });
+      const res = await httpRequest({
+        hostname: '127.0.0.1',
+        port: inst.port,
+        path: '/api/sessions',
+        method: 'GET',
+        headers: { Accept: '*/*' },
+      });
+      assert.strictEqual(res.statusCode, 401);
+      const data = JSON.parse(res.data);
+      assert.strictEqual(data.error, 'unauthorized');
+    });
+
     it('POST /api/auth with wrong password should return 401', async () => {
       inst?.shutdown();
       inst = await startServer({ password: 'secret123' });
@@ -561,7 +576,7 @@ describe('Routes', () => {
       assert.ok(data.url.includes('?ott='), 'URL should contain share token parameter');
     });
 
-    it('should return 401/302 when not authenticated', async () => {
+    it('should return 401 when not authenticated', async () => {
       if (!inst) inst = await startServer({ password: 'secret' });
       const res = await httpRequest({
         hostname: '127.0.0.1',
@@ -569,8 +584,7 @@ describe('Routes', () => {
         path: '/api/share-token',
         method: 'GET',
       });
-      // API endpoint returns 401 (not HTML-accepting)
-      assert.ok(res.statusCode === 401 || res.statusCode === 302);
+      assert.strictEqual(res.statusCode, 401);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #38 — Makes auth middleware use path-based routing instead of content negotiation.

### Changes
- `/api/*` routes always return JSON `401`/`429` (never redirect)
- UI routes (`/`, `/terminal`) redirect to `/login` when unauthenticated
- Updated unit tests in `auth.test.js` to verify both behaviors
- Added integration test in `routes.test.js` confirming API routes return JSON 401
- Updated security docs

### Testing
- All existing tests pass
- New tests verify API routes get JSON 401 even with `Accept: */*`
- New tests verify UI routes still redirect to login