### PR TITLE
fix(auth): make share tokens one-time use

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -29,7 +29,7 @@ TermBeam is designed for **trusted local networks**. It is NOT designed as a pro
 
 - On startup, a **share token** is generated and embedded in the QR code URL as `?ott=<token>`
 - Scanning the QR code sets a full session cookie and redirects to the clean URL — no password typing required
-- Share tokens are **reusable within their validity window** to handle tunnel proxy retries and link preview services
+- Share tokens are **one-time use** — consumed on first successful login to prevent replay attacks
 - Share tokens **expire after 5 minutes**
 - The share button generates a fresh share token via `GET /api/share-token` (authenticated endpoint)
 - If the user already has a valid session cookie, a repeated `?ott=` request simply redirects without re-validating

--- a/src/auth.js
+++ b/src/auth.js
@@ -103,9 +103,8 @@ function createAuth(password) {
       log.warn(`Share: expired token ${tag}…`);
       return false;
     }
-    const min = Math.floor(remaining / 60);
-    const sec = remaining % 60;
-    log.info(`Share: valid token ${tag}… (${min}m ${sec}s remaining)`);
+    shareTokens.delete(token);
+    log.info('share token consumed');
     return true;
   }
 

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -319,11 +319,11 @@ describe('Auth', () => {
       assert.strictEqual(auth.validateShareToken(token), true);
     });
 
-    it('should allow reuse within expiry window', () => {
+    it('should NOT allow reuse after consumption', () => {
       const auth = createAuth('pw');
       const token = auth.generateShareToken();
       assert.strictEqual(auth.validateShareToken(token), true);
-      assert.strictEqual(auth.validateShareToken(token), true);
+      assert.strictEqual(auth.validateShareToken(token), false);
     });
 
     it('should reject an unknown share token', () => {

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -426,6 +426,37 @@ describe('Routes', () => {
       );
     });
 
+    it('GET /?ott=<valid> should fail on second use (one-time token)', async () => {
+      if (!inst) {
+        inst?.shutdown();
+        inst = await startServer({ password: 'secret' });
+      }
+      const ott = inst.auth.generateShareToken();
+      // First use — should succeed
+      const first = await httpRequest({
+        hostname: '127.0.0.1',
+        port: inst.port,
+        path: `/?ott=${ott}`,
+        method: 'GET',
+      });
+      assert.strictEqual(first.statusCode, 302);
+      assert.ok(first.headers['set-cookie']);
+
+      // Second use — token already consumed, should fall through to auth middleware
+      const second = await httpRequest({
+        hostname: '127.0.0.1',
+        port: inst.port,
+        path: `/?ott=${ott}`,
+        method: 'GET',
+      });
+      // Should either redirect to /login (302) or serve login page — NOT set a new cookie
+      const secondCookies = second.headers['set-cookie'] || [];
+      assert.ok(
+        !secondCookies.some((c) => c.startsWith('pty_token=')),
+        'Should not set pty_token on second use of consumed token',
+      );
+    });
+
     it('GET /?ott= is ignored when no password is set', async () => {
       inst?.shutdown();
       inst = await startServer({ password: null });


### PR DESCRIPTION
## Summary

Fixes #39 — Share tokens are now consumed on first successful login, preventing replay attacks.

### Changes
- `validateShareToken()` deletes the token after successful validation (one-time use)
- Log message simplified to `share token consumed` (no token prefix logged)
- Updated unit test to verify second use fails
- Added integration test confirming second OTT use doesn't set a cookie
- Updated security docs to reflect one-time behavior

### Testing
- All existing tests pass
- Unit test verifies second `validateShareToken()` call returns false
- Integration test verifies second `?ott=` request doesn't authenticate