### PR TITLE
feat(security): restrict directory browsing to config.cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,19 +108,20 @@ termbeam --host 0.0.0.0           # allow LAN access (default: 127.0.0.1)
 termbeam --lan                    # shortcut for --host 0.0.0.0
 ```
 
-| Flag                  | Description                                          | Default        |
-| --------------------- | ---------------------------------------------------- | -------------- |
-| `--password <pw>`     | Set access password (also accepts `--password=<pw>`) | Auto-generated |
-| `--no-password`       | Disable password (cannot combine with `--public`)    | —              |
-| `--generate-password` | Auto-generate a secure password                      | On             |
-| `--tunnel`            | Create an ephemeral devtunnel URL (private)          | On             |
-| `--no-tunnel`         | Disable tunnel (LAN-only)                            | —              |
-| `--persisted-tunnel`  | Create a reusable devtunnel URL                      | Off            |
-| `--public`            | Allow public tunnel access                           | Off            |
-| `--port <port>`       | Server port                                          | `3456`         |
-| `--host <addr>`       | Bind address                                         | `127.0.0.1`    |
-| `--lan`               | Bind to all interfaces (LAN access)                  | Off            |
-| `--log-level <level>` | Log verbosity (error/warn/info/debug)                | `info`         |
+| Flag                     | Description                                          | Default        |
+| ------------------------ | ---------------------------------------------------- | -------------- |
+| `--password <pw>`        | Set access password (also accepts `--password=<pw>`) | Auto-generated |
+| `--no-password`          | Disable password (cannot combine with `--public`)    | —              |
+| `--generate-password`    | Auto-generate a secure password                      | On             |
+| `--tunnel`               | Create an ephemeral devtunnel URL (private)          | On             |
+| `--no-tunnel`            | Disable tunnel (LAN-only)                            | —              |
+| `--persisted-tunnel`     | Create a reusable devtunnel URL                      | Off            |
+| `--public`               | Allow public tunnel access                           | Off            |
+| `--port <port>`          | Server port                                          | `3456`         |
+| `--host <addr>`          | Bind address                                         | `127.0.0.1`    |
+| `--lan`                  | Bind to all interfaces (LAN access)                  | Off            |
+| `--log-level <level>`    | Log verbosity (error/warn/info/debug)                | `info`         |
+| `--allow-fs-browse-root` | Allow directory browsing outside working directory   | Off            |
 
 Environment variables: `PORT`, `TERMBEAM_PASSWORD`, `TERMBEAM_CWD`, `TERMBEAM_LOG_LEVEL`, `SHELL` (Unix fallback), `COMSPEC` (Windows fallback). See [Configuration docs](https://dorlugasigal.github.io/TermBeam/configuration/).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,21 +7,22 @@ description: All TermBeam CLI flags and options — ports, passwords, tunnels, s
 
 ## CLI Flags
 
-| Flag                  | Description                                                      | Default   |
-| --------------------- | ---------------------------------------------------------------- | --------- |
-| `--password <pw>`     | Set access password (also accepts `--password=<pw>`)             | None      |
-| `--generate-password` | Auto-generate a secure password (default behavior)               | On        |
-| `--no-password`       | Disable auto-generated password (cannot combine with `--public`) | —         |
-| `--tunnel`            | Create an ephemeral devtunnel URL (private access)               | On        |
-| `--no-tunnel`         | Disable tunnel                                                   | —         |
-| `--persisted-tunnel`  | Create a reusable devtunnel URL (stable across restarts)         | Off       |
-| `--public`            | Allow public tunnel access (no Microsoft login required)         | Off       |
-| `--port <port>`       | Server port                                                      | `3456`    |
-| `--host <addr>`       | Bind address                                                     | `127.0.0.1` |
-| `--lan`               | Bind to all interfaces (LAN access)                              | Off       |
-| `-h, --help`          | Show help                                                        | —         |
-| `-v, --version`       | Show version                                                     | —         |
-| `--log-level <level>` | Set log verbosity: `error`, `warn`, `info`, `debug`              | `info`    |
+| Flag                     | Description                                                      | Default     |
+| ------------------------ | ---------------------------------------------------------------- | ----------- |
+| `--password <pw>`        | Set access password (also accepts `--password=<pw>`)             | None        |
+| `--generate-password`    | Auto-generate a secure password (default behavior)               | On          |
+| `--no-password`          | Disable auto-generated password (cannot combine with `--public`) | —           |
+| `--tunnel`               | Create an ephemeral devtunnel URL (private access)               | On          |
+| `--no-tunnel`            | Disable tunnel                                                   | —           |
+| `--persisted-tunnel`     | Create a reusable devtunnel URL (stable across restarts)         | Off         |
+| `--public`               | Allow public tunnel access (no Microsoft login required)         | Off         |
+| `--port <port>`          | Server port                                                      | `3456`      |
+| `--host <addr>`          | Bind address                                                     | `127.0.0.1` |
+| `--lan`                  | Bind to all interfaces (LAN access)                              | Off         |
+| `-h, --help`             | Show help                                                        | —           |
+| `-v, --version`          | Show version                                                     | —           |
+| `--log-level <level>`    | Set log verbosity: `error`, `warn`, `info`, `debug`              | `info`      |
+| `--allow-fs-browse-root` | Allow directory browsing outside working directory               | Off         |
 
 ## Environment Variables
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -41,6 +41,12 @@ TermBeam is designed for **trusted local networks**. It is NOT designed as a pro
 - Arbitrary shell paths are rejected — only shells returned by `GET /api/shells` are allowed
 - The `cwd` parameter is validated to be an existing, absolute directory path
 
+### Directory Browsing Restriction
+
+- By default, the `/api/dirs` endpoint only lists directories under the configured working directory (`config.cwd`)
+- Requests for paths outside the working directory return HTTP `403`
+- Use `--allow-fs-browse-root` to allow browsing the full filesystem (not recommended when using tunnels)
+
 ### WebSocket Origin Validation
 
 - WebSocket connections include Origin header checks

--- a/src/cli.js
+++ b/src/cli.js
@@ -23,6 +23,7 @@ Options:
   --host <addr>         Bind address (default: 127.0.0.1)
   --lan                 Bind to 0.0.0.0 (allow LAN access, default: localhost only)
   --log-level <level>   Set log verbosity: error, warn, info, debug (default: info)
+  --allow-fs-browse-root  Allow directory browsing outside working directory
   -h, --help            Show this help
   -v, --version         Show version
 
@@ -233,6 +234,7 @@ function parseArgs() {
   let persistedTunnel = false;
   let publicTunnel = false;
   let explicitPassword = !!password;
+  let allowFsBrowseRoot = false;
 
   const args = process.argv.slice(2);
   const filteredArgs = [];
@@ -274,6 +276,8 @@ function parseArgs() {
       host = args[++i];
     } else if (args[i] === '--log-level' && args[i + 1]) {
       logLevel = args[++i];
+    } else if (args[i] === '--allow-fs-browse-root') {
+      allowFsBrowseRoot = true;
     } else {
       filteredArgs.push(args[i]);
     }
@@ -326,6 +330,7 @@ function parseArgs() {
     defaultShell,
     version,
     logLevel,
+    allowFsBrowseRoot,
   };
 }
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -233,6 +233,17 @@ function setupRoutes(app, { auth, sessions, config, state }) {
     const dir = endsWithSep ? query : path.dirname(query);
     const prefix = endsWithSep ? '' : path.basename(query);
 
+    // Restrict browsing to config.cwd unless --allow-fs-browse-root is set
+    if (!config.allowFsBrowseRoot) {
+      const resolved = path.resolve(dir);
+      const root = path.resolve(config.cwd);
+      if (!resolved.startsWith(root + path.sep) && resolved !== root) {
+        return res
+          .status(403)
+          .json({ error: 'Directory browsing restricted to working directory' });
+      }
+    }
+
     try {
       const entries = fs.readdirSync(dir, { withFileTypes: true });
       const dirs = entries

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -301,6 +301,20 @@ describe('CLI', () => {
     assert.strictEqual(config.logLevel, 'warn');
   });
 
+  it('should parse --allow-fs-browse-root flag', () => {
+    process.argv = ['node', 'termbeam', '--allow-fs-browse-root'];
+    const { parseArgs } = require('../src/cli');
+    const config = parseArgs();
+    assert.strictEqual(config.allowFsBrowseRoot, true);
+  });
+
+  it('should default allowFsBrowseRoot to false', () => {
+    process.argv = ['node', 'termbeam'];
+    const { parseArgs } = require('../src/cli');
+    const config = parseArgs();
+    assert.strictEqual(config.allowFsBrowseRoot, false);
+  });
+
   it('--log-level flag should override TERMBEAM_LOG_LEVEL env', () => {
     process.env.TERMBEAM_LOG_LEVEL = 'error';
     process.argv = ['node', 'termbeam', '--log-level', 'debug'];

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -145,12 +145,9 @@ describe('Routes', () => {
       assert.ok(body.dirs.length > 0, 'Should have subdirectories');
     });
 
-    it('should return empty dirs for nonexistent path', async () => {
+    it('should return empty dirs for nonexistent path within cwd', async () => {
       if (!inst) inst = await startServer();
-      const fakePath =
-        process.platform === 'win32'
-          ? 'C:\\nonexistent_termbeam_test_dir\\'
-          : '/nonexistent_termbeam_test_dir/';
+      const fakePath = process.cwd() + path.sep + 'nonexistent_termbeam_test_dir' + path.sep;
       const q = encodeURIComponent(fakePath);
       const res = await httpRequest({
         hostname: '127.0.0.1',
@@ -162,6 +159,63 @@ describe('Routes', () => {
       const body = JSON.parse(res.data);
       assert.ok(Array.isArray(body.dirs), 'dirs should be an array');
       assert.strictEqual(body.dirs.length, 0, 'Should have no dirs for nonexistent path');
+    });
+
+    it('should return 403 for paths outside cwd', async () => {
+      if (!inst) inst = await startServer();
+      const outsidePath = process.platform === 'win32' ? 'C:\\' : '/';
+      const q = encodeURIComponent(outsidePath);
+      const res = await httpRequest({
+        hostname: '127.0.0.1',
+        port: inst.port,
+        path: `/api/dirs?q=${q}`,
+        method: 'GET',
+      });
+      assert.strictEqual(res.statusCode, 403);
+      const body = JSON.parse(res.data);
+      assert.ok(body.error.includes('restricted'));
+    });
+
+    it('should return 403 for parent traversal attempts', async () => {
+      if (!inst) inst = await startServer();
+      const traversal = encodeURIComponent(process.cwd() + '/../');
+      const res = await httpRequest({
+        hostname: '127.0.0.1',
+        port: inst.port,
+        path: `/api/dirs?q=${traversal}`,
+        method: 'GET',
+      });
+      assert.strictEqual(res.statusCode, 403);
+    });
+
+    it('should allow browsing within cwd', async () => {
+      if (!inst) inst = await startServer();
+      const q = encodeURIComponent(process.cwd() + path.sep);
+      const res = await httpRequest({
+        hostname: '127.0.0.1',
+        port: inst.port,
+        path: `/api/dirs?q=${q}`,
+        method: 'GET',
+      });
+      assert.strictEqual(res.statusCode, 200);
+      const body = JSON.parse(res.data);
+      assert.ok(Array.isArray(body.dirs));
+    });
+
+    it('should allow unrestricted browsing with allowFsBrowseRoot', async () => {
+      inst?.shutdown();
+      inst = await startServer({ allowFsBrowseRoot: true });
+      const outsidePath = process.platform === 'win32' ? 'C:\\' : '/tmp/';
+      const q = encodeURIComponent(outsidePath);
+      const res = await httpRequest({
+        hostname: '127.0.0.1',
+        port: inst.port,
+        path: `/api/dirs?q=${q}`,
+        method: 'GET',
+      });
+      assert.strictEqual(res.statusCode, 200);
+      const body = JSON.parse(res.data);
+      assert.ok(Array.isArray(body.dirs));
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #40 — Directory browsing via `/api/dirs` is now restricted to `config.cwd` by default.

### Changes
- `/api/dirs` returns 403 for paths outside working directory
- Added `--allow-fs-browse-root` CLI flag to opt out
- Updated CLI help text
- Added tests for traversal attempts and opt-out flag
- Updated configuration and security docs
- Updated README

### Testing
- All existing tests pass
- New tests verify 403 for `/`, `../`, and paths outside cwd
- New test verifies `allowFsBrowseRoot` allows unrestricted browsing