### PR TITLE
fix(upload): return opaque IDs instead of absolute file paths

### DIFF
--- a/public/terminal.html
+++ b/public/terminal.html
@@ -3237,8 +3237,8 @@
                   const data = await res.json();
                   const ms = managed.get(activeId);
                   if (ms && ms.ws && ms.ws.readyState === 1) {
-                    ms.ws.send(JSON.stringify({ type: 'input', data: data.path + ' ' }));
-                    showToast('Image pasted: ' + data.path.split(/[/\\]/).pop());
+                    ms.ws.send(JSON.stringify({ type: 'input', data: data.url + ' ' }));
+                    showToast('Image pasted: ' + data.id);
                   }
                   return;
                 }
@@ -3412,8 +3412,8 @@
                 const data = await res.json();
                 const ms = managed.get(activeId);
                 if (ms && ms.ws && ms.ws.readyState === 1) {
-                  ms.ws.send(JSON.stringify({ type: 'input', data: data.path + ' ' }));
-                  showToast('Image pasted: ' + data.path.split(/[/\\]/).pop());
+                  ms.ws.send(JSON.stringify({ type: 'input', data: data.url + ' ' }));
+                  showToast('Image pasted: ' + data.id);
                 }
               } catch (err) {
                 showToast('Image paste failed');

--- a/src/routes.js
+++ b/src/routes.js
@@ -7,7 +7,7 @@ const { detectShells } = require('./shells');
 const log = require('./logger');
 
 const PUBLIC_DIR = path.join(__dirname, '..', 'public');
-const uploadedFiles = [];
+const uploadedFiles = new Map(); // id -> filepath
 
 function setupRoutes(app, { auth, sessions, config, state }) {
   // Serve static files (manifest.json, sw.js, icons, etc.)
@@ -212,18 +212,30 @@ function setupRoutes(app, { auth, sessions, config, state }) {
           'image/webp': '.webp',
           'image/bmp': '.bmp',
         }[contentType] || '.png';
-      const filename = `termbeam-${crypto.randomUUID()}${ext}`;
+      const id = crypto.randomUUID();
+      const filename = `termbeam-${id}${ext}`;
       const filepath = path.join(os.tmpdir(), filename);
       fs.writeFileSync(filepath, buffer);
-      uploadedFiles.push(filepath);
+      uploadedFiles.set(id, filepath);
       log.info(`Upload: ${filename} (${buffer.length} bytes)`);
-      res.json({ path: filepath });
+      res.json({ id, url: `/uploads/${id}` });
     });
 
     req.on('error', (err) => {
       log.error(`Upload error: ${err.message}`);
       res.status(500).json({ error: 'Upload failed' });
     });
+  });
+
+  // Serve uploaded files by opaque ID
+  app.get('/uploads/:id', auth.middleware, (req, res) => {
+    const filepath = uploadedFiles.get(req.params.id);
+    if (!filepath) return res.status(404).json({ error: 'not found' });
+    if (!fs.existsSync(filepath)) {
+      uploadedFiles.delete(req.params.id);
+      return res.status(404).json({ error: 'not found' });
+    }
+    res.sendFile(filepath);
   });
 
   // Directory listing for folder browser
@@ -248,7 +260,7 @@ function setupRoutes(app, { auth, sessions, config, state }) {
 }
 
 function cleanupUploadedFiles() {
-  for (const filepath of uploadedFiles) {
+  for (const [id, filepath] of uploadedFiles) {
     try {
       if (fs.existsSync(filepath)) {
         fs.unlinkSync(filepath);
@@ -257,7 +269,7 @@ function cleanupUploadedFiles() {
       log.error(`Failed to cleanup ${filepath}: ${err.message}`);
     }
   }
-  uploadedFiles.length = 0;
+  uploadedFiles.clear();
 }
 
 module.exports = { setupRoutes, cleanupUploadedFiles };

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -58,7 +58,7 @@ describe('Routes', () => {
     let inst;
     after(() => inst?.shutdown());
 
-    it('should accept valid image upload and return path', async () => {
+    it('should accept valid image upload and return opaque id', async () => {
       inst = await startServer();
       const imageData = Buffer.from('fakepngdata');
       const res = await httpRequest(
@@ -73,8 +73,47 @@ describe('Routes', () => {
       );
       assert.strictEqual(res.statusCode, 200);
       const body = JSON.parse(res.data);
-      assert.ok(body.path, 'Response should contain a path');
-      assert.ok(body.path.includes('termbeam-'), 'Path should contain termbeam prefix');
+      assert.ok(body.id, 'Response should contain an id');
+      assert.ok(body.url, 'Response should contain a url');
+      assert.strictEqual(body.url, `/uploads/${body.id}`);
+      assert.strictEqual(body.path, undefined, 'Response must not contain absolute path');
+    });
+
+    it('GET /uploads/:id should serve uploaded file', async () => {
+      if (!inst) inst = await startServer();
+      const imageData = Buffer.from('fakepngdata');
+      const uploadRes = await httpRequest(
+        {
+          hostname: '127.0.0.1',
+          port: inst.port,
+          path: '/api/upload',
+          method: 'POST',
+          headers: { 'Content-Type': 'image/png', 'Content-Length': imageData.length },
+        },
+        imageData,
+      );
+      const body = JSON.parse(uploadRes.data);
+      const getRes = await httpRequest({
+        hostname: '127.0.0.1',
+        port: inst.port,
+        path: body.url,
+        method: 'GET',
+      });
+      assert.strictEqual(getRes.statusCode, 200);
+      assert.strictEqual(getRes.data, imageData.toString());
+    });
+
+    it('GET /uploads/:id should return 404 for unknown id', async () => {
+      if (!inst) inst = await startServer();
+      const getRes = await httpRequest({
+        hostname: '127.0.0.1',
+        port: inst.port,
+        path: '/uploads/nonexistent-id',
+        method: 'GET',
+      });
+      assert.strictEqual(getRes.statusCode, 404);
+      const body = JSON.parse(getRes.data);
+      assert.strictEqual(body.error, 'not found');
     });
 
     it('should reject non-image content-type with 400', async () => {


### PR DESCRIPTION
## Summary

Change the upload endpoint to return opaque identifiers instead of absolute server file paths, preventing filesystem information disclosure.

## Changes

- **`src/routes.js`**:
  - Changed `uploadedFiles` from array to `Map<id, filepath>`
  - Upload returns `{ id, url: '/uploads/<id>' }` instead of `{ path: '/tmp/...' }`
  - Added `GET /uploads/:id` route (auth-protected) to serve uploaded files by opaque ID
  - Updated `cleanupUploadedFiles()` to use Map iteration
- **`public/terminal.html`**: Updated both paste handlers to use `data.url` and `data.id` instead of `data.path`
- **`test/routes.test.js`**: Updated existing upload test to verify `id`/`url` (no `path`); added tests for serving uploads and 404 for unknown IDs

## Acceptance Criteria

- [x] Upload returns `{ id, url }` — no absolute path exposed
- [x] `GET /uploads/:id` route serves files (auth-protected)
- [x] Cleanup still works with Map
- [x] Frontend updated to use new response format

Closes #43