### PR TITLE
feat(upload): validate image content by magic bytes

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -9,6 +9,30 @@ const log = require('./logger');
 const PUBLIC_DIR = path.join(__dirname, '..', 'public');
 const uploadedFiles = [];
 
+const IMAGE_SIGNATURES = [
+  { type: 'image/png', bytes: [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] },
+  { type: 'image/jpeg', bytes: [0xff, 0xd8, 0xff] },
+  { type: 'image/gif', bytes: [0x47, 0x49, 0x46, 0x38] },
+  { type: 'image/webp', offset: 8, bytes: [0x57, 0x45, 0x42, 0x50] },
+  { type: 'image/bmp', bytes: [0x42, 0x4d] },
+];
+
+function validateMagicBytes(buffer, contentType) {
+  const sig = IMAGE_SIGNATURES.find((s) => s.type === contentType);
+  if (!sig) return true; // unknown type, skip validation
+  const offset = sig.offset || 0;
+  if (buffer.length < offset + sig.bytes.length) return false;
+  const match = sig.bytes.every((b, i) => buffer[offset + i] === b);
+  if (!match) return false;
+  // WebP requires RIFF header at offset 0
+  if (contentType === 'image/webp') {
+    const riff = [0x52, 0x49, 0x46, 0x46];
+    if (buffer.length < 4) return false;
+    return riff.every((b, i) => buffer[i] === b);
+  }
+  return true;
+}
+
 function setupRoutes(app, { auth, sessions, config, state }) {
   // Serve static files (manifest.json, sw.js, icons, etc.)
   app.use(express.static(PUBLIC_DIR, { index: false }));
@@ -203,6 +227,10 @@ function setupRoutes(app, { auth, sessions, config, state }) {
       const buffer = Buffer.concat(chunks);
       if (!buffer.length) {
         return res.status(400).json({ error: 'No image data' });
+      }
+      if (!validateMagicBytes(buffer, contentType)) {
+        log.warn(`Upload rejected: content-type "${contentType}" does not match file signature`);
+        return res.status(400).json({ error: 'File content does not match declared image type' });
       }
       const ext =
         {

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -60,7 +60,7 @@ describe('Routes', () => {
 
     it('should accept valid image upload and return path', async () => {
       inst = await startServer();
-      const imageData = Buffer.from('fakepngdata');
+      const imageData = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00]);
       const res = await httpRequest(
         {
           hostname: '127.0.0.1',
@@ -106,6 +106,137 @@ describe('Routes', () => {
       assert.strictEqual(res.statusCode, 400);
       const body = JSON.parse(res.data);
       assert.strictEqual(body.error, 'No image data');
+    });
+
+    it('should accept valid JPEG magic bytes', async () => {
+      if (!inst) inst = await startServer();
+      const imageData = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+      const res = await httpRequest(
+        {
+          hostname: '127.0.0.1',
+          port: inst.port,
+          path: '/api/upload',
+          method: 'POST',
+          headers: { 'Content-Type': 'image/jpeg', 'Content-Length': imageData.length },
+        },
+        imageData,
+      );
+      assert.strictEqual(res.statusCode, 200);
+      const body = JSON.parse(res.data);
+      assert.ok(body.path, 'Response should contain a path');
+    });
+
+    it('should accept valid GIF magic bytes', async () => {
+      if (!inst) inst = await startServer();
+      // GIF89a header
+      const imageData = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00]);
+      const res = await httpRequest(
+        {
+          hostname: '127.0.0.1',
+          port: inst.port,
+          path: '/api/upload',
+          method: 'POST',
+          headers: { 'Content-Type': 'image/gif', 'Content-Length': imageData.length },
+        },
+        imageData,
+      );
+      assert.strictEqual(res.statusCode, 200);
+    });
+
+    it('should accept valid WebP magic bytes', async () => {
+      if (!inst) inst = await startServer();
+      // RIFF....WEBP header
+      const imageData = Buffer.from([
+        0x52, 0x49, 0x46, 0x46, // RIFF
+        0x24, 0x00, 0x00, 0x00, // file size
+        0x57, 0x45, 0x42, 0x50, // WEBP
+        0x00, 0x00, 0x00, 0x00,
+      ]);
+      const res = await httpRequest(
+        {
+          hostname: '127.0.0.1',
+          port: inst.port,
+          path: '/api/upload',
+          method: 'POST',
+          headers: { 'Content-Type': 'image/webp', 'Content-Length': imageData.length },
+        },
+        imageData,
+      );
+      assert.strictEqual(res.statusCode, 200);
+    });
+
+    it('should accept valid BMP magic bytes', async () => {
+      if (!inst) inst = await startServer();
+      // BM header
+      const imageData = Buffer.from([0x42, 0x4d, 0x36, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+      const res = await httpRequest(
+        {
+          hostname: '127.0.0.1',
+          port: inst.port,
+          path: '/api/upload',
+          method: 'POST',
+          headers: { 'Content-Type': 'image/bmp', 'Content-Length': imageData.length },
+        },
+        imageData,
+      );
+      assert.strictEqual(res.statusCode, 200);
+    });
+
+    it('should reject WebP data missing RIFF header', async () => {
+      if (!inst) inst = await startServer();
+      // Has WEBP at offset 8 but no RIFF at offset 0
+      const imageData = Buffer.from([
+        0x00, 0x00, 0x00, 0x00, // NOT RIFF
+        0x24, 0x00, 0x00, 0x00,
+        0x57, 0x45, 0x42, 0x50, // WEBP
+      ]);
+      const res = await httpRequest(
+        {
+          hostname: '127.0.0.1',
+          port: inst.port,
+          path: '/api/upload',
+          method: 'POST',
+          headers: { 'Content-Type': 'image/webp', 'Content-Length': imageData.length },
+        },
+        imageData,
+      );
+      assert.strictEqual(res.statusCode, 400);
+    });
+
+    it('should reject fake data with image/png content-type', async () => {
+      if (!inst) inst = await startServer();
+      const imageData = Buffer.from('this is not a png');
+      const res = await httpRequest(
+        {
+          hostname: '127.0.0.1',
+          port: inst.port,
+          path: '/api/upload',
+          method: 'POST',
+          headers: { 'Content-Type': 'image/png', 'Content-Length': imageData.length },
+        },
+        imageData,
+      );
+      assert.strictEqual(res.statusCode, 400);
+      const body = JSON.parse(res.data);
+      assert.strictEqual(body.error, 'File content does not match declared image type');
+    });
+
+    it('should reject JPEG data with image/png content-type', async () => {
+      if (!inst) inst = await startServer();
+      const imageData = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+      const res = await httpRequest(
+        {
+          hostname: '127.0.0.1',
+          port: inst.port,
+          path: '/api/upload',
+          method: 'POST',
+          headers: { 'Content-Type': 'image/png', 'Content-Length': imageData.length },
+        },
+        imageData,
+      );
+      assert.strictEqual(res.statusCode, 400);
+      const body = JSON.parse(res.data);
+      assert.strictEqual(body.error, 'File content does not match declared image type');
     });
   });
 


### PR DESCRIPTION
## Summary

Add magic-byte validation to the upload endpoint to verify that uploaded files actually match their declared `Content-Type`. Supports PNG, JPEG, GIF, WebP, and BMP formats.

## Changes

- **`src/routes.js`**: Added `IMAGE_SIGNATURES` array and `validateMagicBytes()` function. Validation runs after buffer assembly and before file write. Mismatched magic bytes return 400. WebP validation checks both RIFF header (offset 0) and WEBP signature (offset 8).
- **`test/routes.test.js`**: Updated existing PNG test to use real magic bytes. Added 7 new tests covering: valid JPEG/GIF/WebP/BMP uploads, fake data rejection, content-type mismatch (JPEG as PNG), and WebP missing RIFF header.

## Acceptance Criteria

- [x] Validate first bytes for PNG, JPEG, GIF, WebP, BMP
- [x] Reject mismatches with 400 and clear error message
- [x] Keep existing 10MB limit
- [x] Tests for spoofed content-type

Closes #42