### PR TITLE
feat(service): add interactive PM2 service wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ termbeam [shell] [args...]        # start with a specific shell (default: auto-d
 termbeam --port 8080              # custom port (default: 3456)
 termbeam --host 0.0.0.0           # allow LAN access (default: 127.0.0.1)
 termbeam --lan                    # shortcut for --host 0.0.0.0
+termbeam service install          # interactive PM2 service setup wizard
+termbeam service uninstall        # stop & remove PM2 service
+termbeam service status           # show PM2 service status
+termbeam service logs             # tail PM2 service logs
+termbeam service restart          # restart PM2 service
 ```
 
 | Flag                  | Description                                          | Default        |
@@ -123,6 +128,14 @@ termbeam --lan                    # shortcut for --host 0.0.0.0
 | `--log-level <level>` | Log verbosity (error/warn/info/debug)                | `info`         |
 | `-h, --help`          | Show help                                            | —              |
 | `-v, --version`       | Show version                                         | —              |
+
+| Subcommand          | Description                   |
+| ------------------- | ----------------------------- |
+| `service install`   | Interactive PM2 service setup |
+| `service uninstall` | Stop & remove from PM2        |
+| `service status`    | Show PM2 service status       |
+| `service logs`      | Tail PM2 service logs         |
+| `service restart`   | Restart PM2 service           |
 
 Environment variables: `PORT`, `TERMBEAM_PASSWORD`, `TERMBEAM_CWD`, `TERMBEAM_LOG_LEVEL`, `SHELL` (Unix fallback), `COMSPEC` (Windows fallback). See [Configuration docs](https://dorlugasigal.github.io/TermBeam/configuration/).
 

--- a/bin/termbeam.js
+++ b/bin/termbeam.js
@@ -1,2 +1,27 @@
 #!/usr/bin/env node
-require('../src/server.js');
+
+// Dispatch subcommands before loading the server
+const subcommand = (process.argv[2] || '').toLowerCase();
+if (subcommand === 'service') {
+  const { run } = require('../src/service');
+  run(process.argv.slice(3)).catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+  });
+} else {
+  const { createTermBeamServer } = require('../src/server.js');
+  const instance = createTermBeamServer();
+
+  process.on('SIGINT', () => {
+    console.log('\n[termbeam] Shutting down...');
+    instance.shutdown();
+    setTimeout(() => process.exit(0), 500).unref();
+  });
+  process.on('SIGTERM', () => {
+    console.log('\n[termbeam] Shutting down...');
+    instance.shutdown();
+    setTimeout(() => process.exit(0), 500).unref();
+  });
+
+  instance.start();
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,26 @@ description: All TermBeam CLI flags and options — ports, passwords, tunnels, s
 !!! info "Legacy Variables"
     The environment variables `PTY_PASSWORD` and `PTY_CWD` are also supported as fallbacks for `TERMBEAM_PASSWORD` and `TERMBEAM_CWD` respectively.
 
+## Subcommands
+
+### `termbeam service`
+
+TermBeam includes a `service` subcommand for managing a PM2-based background service. Run `termbeam service install` to launch an interactive wizard that configures and starts the service.
+
+| Subcommand          | Description                                                           |
+| ------------------- | --------------------------------------------------------------------- |
+| `service install`   | Interactive wizard — configures password, port, access mode, and more |
+| `service uninstall` | Stops the PM2 process, removes it, and deletes the ecosystem config   |
+| `service status`    | Shows detailed PM2 process status (uptime, memory, restarts)          |
+| `service logs`      | Tails PM2 logs (last 200 lines + live stream)                         |
+| `service restart`   | Restarts the PM2 process                                              |
+
+<!-- prettier-ignore -->
+!!! info "Ecosystem config"
+    The wizard saves its configuration to `~/.termbeam/ecosystem.config.js`. You can edit this file manually and run `termbeam service restart` to apply changes.
+
+For a full walkthrough of the wizard steps and each subcommand, see [Running in Background](running-in-background.md#interactive-setup-easiest).
+
 ## Examples
 
 ### Basic Usage

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,3 +118,13 @@ The bottom touch bar provides quick access to:
 | ^C      | Ctrl+C (interrupt process)                          |
 
 Font size can be adjusted with **−** / **+** buttons in the top toolbar.
+
+## Running as a Service
+
+Want TermBeam always available in the background? The built-in service installer configures [PM2](https://pm2.keymetrics.io/) for you with an interactive wizard:
+
+```bash
+termbeam service install
+```
+
+After installation, manage the service with `termbeam service status`, `logs`, `restart`, or `uninstall`. For the full setup guide and alternative methods (systemd, launchd, Windows), see [Running in Background](running-in-background.md).

--- a/docs/running-in-background.md
+++ b/docs/running-in-background.md
@@ -27,7 +27,75 @@ kill $(cat ~/.termbeam.pid)
 
 [PM2](https://pm2.keymetrics.io/) is the most popular Node.js process manager. It handles restarts, logging, and monitoring out of the box.
 
-### Setup
+### Interactive Setup (Easiest)
+
+TermBeam includes a built-in interactive installer that configures PM2 for you:
+
+```bash
+termbeam service install
+```
+
+The wizard checks if PM2 is installed (and offers to install it globally if not), then walks you through 7 configuration steps:
+
+| Step                     | Question                   | Options / Default                                                 |
+| ------------------------ | -------------------------- | ----------------------------------------------------------------- |
+| 1. **Service name**      | Name for the PM2 process   | Default: `termbeam`                                               |
+| 2. **Password**          | How to protect the service | Auto-generate (recommended), enter custom, or no password         |
+| 3. **Port**              | Server port                | Default: `3456`                                                   |
+| 4. **Access mode**       | How to reach the service   | DevTunnel (from anywhere), LAN (local network), or Localhost only |
+| 5. **Working directory** | Default terminal directory | Default: current directory                                        |
+| 6. **Log level**         | Logging verbosity          | `info` (default), `debug`, `warn`, or `error`                     |
+| 7. **Boot auto-start**   | Start on system boot?      | Default: Yes — runs `pm2 startup`                                 |
+
+If you choose **DevTunnel** access, a follow-up question asks whether the tunnel should be **private** (Microsoft login required) or **public** (anyone with the link). Choosing public with no password will auto-generate one for safety.
+
+After confirming, the wizard generates an ecosystem config file, starts the PM2 process, and saves the process list.
+
+<!-- prettier-ignore -->
+!!! tip "Ecosystem config location"
+    The wizard saves the PM2 ecosystem file to `~/.termbeam/ecosystem.config.js`. This file contains all the CLI flags and environment variables for your service. You can edit it manually and run `termbeam service restart` to apply changes.
+
+### Service Subcommands
+
+After installation, manage the service with these subcommands:
+
+#### `termbeam service status`
+
+Shows detailed PM2 process information (equivalent to `pm2 describe <name>`), including uptime, restarts, memory usage, and log file paths.
+
+```bash
+termbeam service status
+```
+
+#### `termbeam service logs`
+
+Tails the PM2 log output, showing the last 200 lines and streaming new output in real time. Press `Ctrl+C` to stop.
+
+```bash
+termbeam service logs
+```
+
+#### `termbeam service restart`
+
+Restarts the PM2 process. Useful after editing the ecosystem config file or updating TermBeam.
+
+```bash
+termbeam service restart
+```
+
+#### `termbeam service uninstall`
+
+Stops the PM2 process, removes it from PM2, and deletes the ecosystem config file. Prompts for confirmation before proceeding.
+
+```bash
+termbeam service uninstall
+```
+
+<!-- prettier-ignore -->
+!!! warning
+    `uninstall` removes the service from PM2 and deletes the ecosystem config at `~/.termbeam/ecosystem.config.js`. If you've customized the config, back it up first.
+
+### Manual Setup
 
 ```bash
 # Install PM2 globally

--- a/public/terminal.html
+++ b/public/terminal.html
@@ -2050,7 +2050,17 @@
       // ===== Zoom =====
       const MIN_FONT = 2,
         MAX_FONT = 28;
-      let fontSize = parseInt(localStorage.getItem('termbeam-fontsize') || '8', 10);
+      function defaultFontSize() {
+        const w = window.innerWidth;
+        if (w <= 480) return 12;
+        if (w <= 768) return 13;
+        if (w <= 1280) return 14;
+        return 15;
+      }
+      let fontSize = parseInt(
+        localStorage.getItem('termbeam-fontsize') || String(defaultFontSize()),
+        10,
+      );
 
       function applyZoom(size) {
         fontSize = Math.max(MIN_FONT, Math.min(MAX_FONT, size));

--- a/src/auth.js
+++ b/src/auth.js
@@ -5,41 +5,70 @@ const LOGIN_HTML = `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-  <meta name="theme-color" content="#1a1a2e" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="theme-color" content="#1e1e1e" />
   <title>TermBeam — Login</title>
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    html, body { height: 100%; background: #1a1a2e; color: #e0e0e0;
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      display: flex; align-items: center; justify-content: center; }
-    .card { background: #16213e; border: 1px solid #0f3460; border-radius: 16px;
-      padding: 32px 24px; width: 320px; text-align: center; }
-    h1 { font-size: 20px; margin-bottom: 8px; }
-    h1 span { color: #533483; }
-    p { font-size: 13px; color: #888; margin-bottom: 24px; }
-    input { width: 100%; padding: 12px; background: #1a1a2e; border: 1px solid #0f3460;
-      border-radius: 8px; color: #e0e0e0; font-size: 16px; outline: none;
-      text-align: center; letter-spacing: 2px; }
-    input:focus { border-color: #533483; }
-    button { width: 100%; padding: 12px; margin-top: 16px; background: #533483;
-      color: white; border: none; border-radius: 8px; font-size: 16px;
-      font-weight: 600; cursor: pointer; }
-    button:active { background: #6a42a8; }
-    .error { color: #e74c3c; font-size: 13px; margin-top: 12px; display: none; }
+    :root { --bg:#1e1e1e; --surface:#252526; --border:#3c3c3c; --border-subtle:#474747;
+      --text:#d4d4d4; --text-secondary:#858585; --text-dim:#6e6e6e;
+      --accent:#0078d4; --accent-hover:#1a8ae8; --accent-active:#005a9e;
+      --danger:#f14c4c; --shadow:rgba(0,0,0,0.15); }
+    [data-theme='light'] { --bg:#ffffff; --surface:#f3f3f3; --border:#e0e0e0;
+      --border-subtle:#d0d0d0; --text:#1e1e1e; --text-secondary:#616161;
+      --text-dim:#767676; --accent:#0078d4; --accent-hover:#106ebe;
+      --accent-active:#005a9e; --danger:#e51400; --shadow:rgba(0,0,0,0.06); }
+    * { margin:0; padding:0; box-sizing:border-box; }
+    html, body { height:100%; background:var(--bg); color:var(--text);
+      font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+      display:flex; flex-direction:column; align-items:center; justify-content:center;
+      transition:background 0.3s,color 0.3s;
+      padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left); }
+    .theme-toggle { position:fixed; top:16px; right:16px; background:none;
+      border:1px solid var(--border); color:var(--text-dim); width:32px; height:32px;
+      border-radius:8px; cursor:pointer; display:flex; align-items:center;
+      justify-content:center; font-size:16px; transition:color 0.15s,border-color 0.15s,background 0.15s;
+      -webkit-tap-highlight-color:transparent; z-index:10; }
+    .theme-toggle:hover { color:var(--text); border-color:var(--border-subtle); background:var(--border); }
+    .card { background:var(--surface); border:1px solid var(--border); border-radius:12px;
+      padding:32px 24px; width:320px; max-width:calc(100vw - 32px); text-align:center;
+      box-shadow:0 2px 8px var(--shadow); transition:background 0.3s,border-color 0.3s,box-shadow 0.3s; }
+    h1 { font-size:22px; font-weight:700; margin-bottom:4px; }
+    h1 span { color:var(--accent); }
+    .subtitle { font-size:13px; color:var(--text-secondary); margin-bottom:24px; }
+    input { width:100%; padding:12px; background:var(--bg); border:1px solid var(--border);
+      border-radius:8px; color:var(--text); font-size:16px; outline:none;
+      text-align:center; letter-spacing:2px; transition:border-color 0.15s,background 0.3s,color 0.3s; }
+    input:focus { border-color:var(--accent); }
+    .btn { width:100%; padding:12px; margin-top:16px; background:var(--accent);
+      color:#fff; border:none; border-radius:8px; font-size:16px;
+      font-weight:600; cursor:pointer; transition:background 0.15s; }
+    .btn:hover { background:var(--accent-hover); }
+    .btn:active { background:var(--accent-active); }
+    .error { color:var(--danger); font-size:13px; margin-top:12px; display:none; transition:color 0.3s; }
+    .tagline { margin-top:24px; font-size:12px; color:var(--text-dim); transition:color 0.3s; }
   </style>
 </head>
 <body>
+  <button class="theme-toggle" id="themeBtn" aria-label="Toggle theme">🌙</button>
   <div class="card">
     <h1>📡 Term<span>Beam</span></h1>
-    <p>Enter the access password</p>
+    <p class="subtitle">Enter the access password</p>
     <form id="form">
       <input type="password" id="pw" placeholder="Password" autocomplete="off" autofocus />
-      <button type="submit">Unlock</button>
+      <button type="submit" class="btn">Unlock</button>
     </form>
     <div class="error" id="err">Incorrect password</div>
   </div>
+  <p class="tagline">Beam your terminal to any device</p>
   <script>
+    const t=document.getElementById('themeBtn'), h=document.documentElement;
+    function applyTheme(light){h.setAttribute('data-theme',light?'light':'');t.textContent=light?'☀️':'🌙';
+      document.querySelector('meta[name=theme-color]').content=light?'#ffffff':'#1e1e1e';}
+    applyTheme(localStorage.getItem('theme')==='light');
+    t.addEventListener('click',()=>{const light=h.getAttribute('data-theme')!=='light';
+      localStorage.setItem('theme',light?'light':'dark');applyTheme(light);});
     document.getElementById('form').addEventListener('submit', async (e) => {
       e.preventDefault();
       const pw = document.getElementById('pw').value;

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,6 +10,14 @@ termbeam — Beam your terminal to any device
 
 Usage:
   termbeam [options] [shell] [args...]
+  termbeam service <action>            Manage as a background service (PM2)
+
+Actions (service):
+  install      Interactive setup & start as PM2 service
+  uninstall    Stop & remove from PM2
+  status       Show service status
+  logs         Tail service logs
+  restart      Restart the service
 
 Options:
   --password <pw>       Set access password (or TERMBEAM_PASSWORD env var)
@@ -39,6 +47,7 @@ Examples:
   termbeam --password secret        Start with specific password
   termbeam --persisted-tunnel       Stable tunnel URL across restarts
   termbeam /bin/bash                Use bash instead of default shell
+  termbeam service install          Set up as background service (PM2)
 
 Environment:
   PORT                  Server port (default: 3456)

--- a/src/server.js
+++ b/src/server.js
@@ -233,9 +233,8 @@ function createTermBeamServer(overrides = {}) {
 
 module.exports = { createTermBeamServer, getLocalIP };
 
-// Auto-start when run directly (CLI entry point)
-const _entryBase = path.basename(process.argv[1] || '');
-if (require.main === module || _entryBase === 'termbeam' || _entryBase === 'termbeam.js') {
+// Auto-start when run directly (e.g. `node src/server.js`)
+if (require.main === module) {
   const instance = createTermBeamServer();
 
   process.on('SIGINT', () => {

--- a/src/service.js
+++ b/src/service.js
@@ -1,0 +1,731 @@
+const { execFileSync, execFile } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+const readline = require('readline');
+
+const TERMBEAM_DIR = path.join(os.homedir(), '.termbeam');
+const ECOSYSTEM_FILE = path.join(TERMBEAM_DIR, 'ecosystem.config.js');
+const DEFAULT_SERVICE_NAME = 'termbeam';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function color(code, text) {
+  return `\x1b[${code}m${text}\x1b[0m`;
+}
+const green = (t) => color('32', t);
+const yellow = (t) => color('33', t);
+const red = (t) => color('31', t);
+const cyan = (t) => color('36', t);
+const bold = (t) => color('1', t);
+const dim = (t) => color('2', t);
+
+/**
+ * Prompt the user with a question. Returns the trimmed answer.
+ * If `defaultValue` is provided, it's shown in brackets and used when the user presses Enter.
+ */
+function ask(rl, question, defaultValue) {
+  const suffix = defaultValue != null ? ` ${dim(`[${defaultValue}]`)} ` : ' ';
+  return new Promise((resolve) => {
+    rl.question(`${question}${suffix}`, (answer) => {
+      const trimmed = answer.trim();
+      resolve(trimmed || (defaultValue != null ? String(defaultValue) : ''));
+    });
+  });
+}
+
+/**
+ * Prompt the user with a list of choices using arrow keys.
+ * Each choice can be a string or { label, hint } object.
+ * Up/Down to move, Enter to select. Returns the chosen value.
+ */
+function choose(rl, question, choices, defaultIndex = 0) {
+  // Normalize choices to { label, hint } objects
+  const items = choices.map((c) => (typeof c === 'string' ? { label: c, hint: '' } : c));
+
+  return new Promise((resolve) => {
+    let selected = defaultIndex;
+
+    function lineCount() {
+      return items.reduce((n, item) => n + 1 + (item.hint ? 1 : 0), 0);
+    }
+
+    function render(clear) {
+      if (clear) {
+        process.stdout.write(`\x1b[${lineCount()}A\r\x1b[J`);
+      }
+      items.forEach((item, i) => {
+        const marker = i === selected ? cyan('→') : ' ';
+        const label = i === selected ? bold(item.label) : item.label;
+        process.stdout.write(`  ${marker} ${label}\n`);
+        if (item.hint) {
+          const hintText = item.danger
+            ? red(item.hint)
+            : item.warn
+              ? yellow(item.hint)
+              : dim(item.hint);
+          process.stdout.write(`      ${hintText}\n`);
+        }
+      });
+      process.stdout.write(dim('  ↑/↓ to move, Enter to select'));
+    }
+
+    rl.pause();
+    console.log(`\n${question}`);
+    render(false);
+
+    const wasRaw = process.stdin.isRaw;
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+    }
+    process.stdin.resume();
+
+    function onKey(buf) {
+      const key = buf.toString();
+
+      if (key === '\x1b[A' || key === 'k') {
+        selected = (selected - 1 + items.length) % items.length;
+        render(true);
+      } else if (key === '\x1b[B' || key === 'j') {
+        selected = (selected + 1) % items.length;
+        render(true);
+      } else if (key === '\r' || key === '\n') {
+        cleanup();
+        process.stdout.write('\r\x1b[K\n');
+        console.log(dim(`  Selected: ${items[selected].label}`));
+        resolve({ index: selected, value: items[selected].label });
+      } else if (key === '\x03') {
+        cleanup();
+        process.exit(0);
+      }
+    }
+
+    function cleanup() {
+      process.stdin.removeListener('data', onKey);
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(wasRaw || false);
+      }
+      process.stdin.pause();
+      rl.resume();
+    }
+
+    process.stdin.on('data', onKey);
+  });
+}
+
+/**
+ * Ask a yes/no question. Returns boolean.
+ */
+function confirm(rl, question, defaultYes = true) {
+  const hint = defaultYes ? 'Y/n' : 'y/N';
+  return new Promise((resolve) => {
+    rl.question(`${question} ${dim(`[${hint}]`)} `, (answer) => {
+      const a = answer.trim().toLowerCase();
+      if (a === '') resolve(defaultYes);
+      else resolve(a === 'y' || a === 'yes');
+    });
+  });
+}
+
+// ── PM2 Detection ────────────────────────────────────────────────────────────
+
+function findPm2() {
+  try {
+    const cmd = os.platform() === 'win32' ? 'where' : 'which';
+    const result = execFileSync(cmd, ['pm2'], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+      timeout: 5000,
+    });
+    return result.trim().split('\n')[0].trim();
+  } catch {
+    return null;
+  }
+}
+
+function installPm2Global() {
+  console.log(yellow('\nInstalling PM2 globally...'));
+  try {
+    execFileSync('npm', ['install', '-g', 'pm2'], {
+      stdio: 'inherit',
+      timeout: 120000,
+    });
+    console.log(green('✓ PM2 installed successfully.\n'));
+    return true;
+  } catch (err) {
+    console.error(red(`✗ Failed to install PM2: ${err.message}`));
+    console.error(dim('  Try running: sudo npm install -g pm2'));
+    return false;
+  }
+}
+
+// ── Ecosystem Config ─────────────────────────────────────────────────────────
+
+function buildArgs(config) {
+  const args = [];
+  if (config.password === false) {
+    args.push('--no-password');
+  } else if (config.password) {
+    args.push('--password', config.password);
+  }
+  if (config.port && config.port !== 3456) {
+    args.push('--port', String(config.port));
+  }
+  if (config.host && config.host !== '127.0.0.1') {
+    args.push('--host', config.host);
+  }
+  if (config.lan) {
+    args.push('--lan');
+  }
+  if (config.noTunnel) {
+    args.push('--no-tunnel');
+  }
+  if (config.persistedTunnel) {
+    args.push('--persisted-tunnel');
+  }
+  if (config.publicTunnel) {
+    args.push('--public');
+  }
+  if (config.logLevel && config.logLevel !== 'info') {
+    args.push('--log-level', config.logLevel);
+  }
+  if (config.shell) {
+    args.push(config.shell);
+  }
+  return args;
+}
+
+function generateEcosystem(config) {
+  const entry = require.resolve('../bin/termbeam.js');
+  const args = buildArgs(config);
+  const env = {};
+  if (config.cwd) env.TERMBEAM_CWD = config.cwd;
+
+  const ecosystem = {
+    apps: [
+      {
+        name: config.name || DEFAULT_SERVICE_NAME,
+        script: entry,
+        args: args,
+        cwd: config.cwd || os.homedir(),
+        env,
+        autorestart: true,
+        max_restarts: 10,
+        restart_delay: 1000,
+      },
+    ],
+  };
+
+  return `module.exports = ${JSON.stringify(ecosystem, null, 2)};\n`;
+}
+
+function writeEcosystem(content) {
+  fs.mkdirSync(TERMBEAM_DIR, { recursive: true });
+  fs.writeFileSync(ECOSYSTEM_FILE, content, 'utf8');
+}
+
+// ── PM2 Commands ─────────────────────────────────────────────────────────────
+
+function pm2Exec(args, opts = {}) {
+  try {
+    return execFileSync('pm2', args, {
+      encoding: 'utf8',
+      stdio: opts.inherit ? 'inherit' : ['pipe', 'pipe', 'pipe'],
+      timeout: 30000,
+      ...opts,
+    });
+  } catch (err) {
+    if (opts.silent) return null;
+    console.error(red(`✗ PM2 command failed: pm2 ${args.join(' ')}`));
+    if (err.stderr) console.error(dim(err.stderr.trim()));
+    return null;
+  }
+}
+
+// ── Actions ──────────────────────────────────────────────────────────────────
+
+async function actionInstall() {
+  console.log(dim('\nChecking PM2...\n'));
+
+  // Step 1: Check PM2
+  let pm2Path = findPm2();
+  if (!pm2Path) {
+    console.log(yellow('⚠ PM2 is not installed.'));
+    console.log(dim('  PM2 is a process manager for Node.js that keeps TermBeam running'));
+    console.log(dim('  in the background and can auto-restart it on boot.\n'));
+
+    const rl = createRL();
+    const shouldInstall = await confirm(rl, 'Install PM2 globally now?', true);
+    rl.close();
+
+    if (!shouldInstall) {
+      console.log(dim('\nYou can install PM2 manually: npm install -g pm2'));
+      console.log(dim('Then run: termbeam service install\n'));
+      process.exit(1);
+    }
+    if (!installPm2Global()) process.exit(1);
+    pm2Path = findPm2();
+    if (!pm2Path) {
+      console.error(red('✗ PM2 still not found after installation.'));
+      process.exit(1);
+    }
+  } else {
+    console.log(green(`✓ PM2 found: ${pm2Path}`));
+  }
+
+  // Enter alternate screen buffer for a clean wizard (like vim/htop)
+  process.stdout.write('\x1b[?1049h');
+  // Ensure we exit alternate screen on any exit
+  const exitAltScreen = () => process.stdout.write('\x1b[?1049l');
+  process.on('exit', exitAltScreen);
+
+  // Step 2: Interactive config
+  const rl = createRL();
+  const config = {};
+
+  const steps = [
+    'Service name',
+    'Password',
+    'Port',
+    'Access',
+    'Directory',
+    'Log level',
+    'Boot',
+    'Confirm',
+  ];
+
+  const decisions = [];
+
+  function showProgress(stepIndex) {
+    // Clear alternate screen and move to top
+    process.stdout.write('\x1b[2J\x1b[H');
+
+    console.log(bold('🚀 TermBeam Service Setup'));
+    console.log('');
+    const total = steps.length;
+    const filled = stepIndex + 1;
+    const bar = steps
+      .map((s, i) => {
+        if (i < stepIndex) return green('●');
+        if (i === stepIndex) return cyan('●');
+        return dim('○');
+      })
+      .join(dim(' ─ '));
+    console.log(`${dim(`Step ${filled}/${total}`)}  ${bar}  ${cyan(steps[stepIndex])}`);
+
+    // Show decisions so far
+    if (decisions.length > 0) {
+      console.log('');
+      for (const { label, value } of decisions) {
+        console.log(`  ${dim(label + ':')} ${value}`);
+      }
+    }
+  }
+
+  // Service name
+  showProgress(0);
+  config.name = await ask(rl, 'Service name:', DEFAULT_SERVICE_NAME);
+  decisions.push({ label: 'Service name', value: config.name });
+
+  // Password
+  showProgress(1);
+  const pwChoice = await choose(rl, 'Password authentication:', [
+    {
+      label: 'Auto-generate a secure password',
+      hint: 'A random password will be created and displayed for you',
+    },
+    { label: 'Enter a custom password', hint: 'You choose the password for accessing TermBeam' },
+    {
+      label: 'No password',
+      hint: '⚠ Not recommended — anyone on the network can access your terminal',
+      warn: true,
+    },
+  ]);
+  if (pwChoice.index === 0) {
+    config.password = crypto.randomBytes(16).toString('base64url');
+    console.log(dim(`  Generated password: ${config.password}`));
+  } else if (pwChoice.index === 1) {
+    config.password = await ask(rl, 'Enter password:');
+    while (!config.password) {
+      console.log(red('  Password cannot be empty.'));
+      config.password = await ask(rl, 'Enter password:');
+    }
+  } else {
+    config.password = false;
+  }
+  decisions.push({
+    label: 'Password',
+    value: config.password === false ? yellow('disabled') : '••••••••',
+  });
+
+  // Port
+  showProgress(2);
+  const portStr = await ask(rl, 'Port:', '3456');
+  config.port = parseInt(portStr, 10) || 3456;
+  decisions.push({ label: 'Port', value: String(config.port) });
+
+  // Access mode (combines host binding + tunnel into one clear question)
+  showProgress(3);
+  const accessChoice = await choose(rl, 'How will you connect to TermBeam?', [
+    {
+      label: 'From anywhere (DevTunnel)',
+      hint: 'Creates a secure tunnel URL — access from phone, other networks, anywhere',
+    },
+    {
+      label: 'Local network (LAN)',
+      hint: 'Accessible from devices on the same Wi-Fi/network (e.g. phone on same Wi-Fi)',
+    },
+    {
+      label: 'This machine only',
+      hint: 'Localhost only — most secure, no external access',
+    },
+  ]);
+
+  if (accessChoice.index === 0) {
+    // DevTunnel mode: localhost binding, tunnel enabled, persisted by default for services
+    config.host = '127.0.0.1';
+    config.noTunnel = false;
+    config.persistedTunnel = true;
+    // Re-render step to clear the previous menu before showing sub-question
+    showProgress(3);
+    const publicChoice = await choose(rl, 'Tunnel access:', [
+      {
+        label: 'Private (requires Microsoft login)',
+        hint: 'Only you can access the tunnel — secured via your Microsoft account',
+      },
+      {
+        label: 'Public (anyone with the link)',
+        hint: '🚨 Anyone with the URL can reach your terminal — password is the only protection',
+        danger: true,
+      },
+    ]);
+    config.publicTunnel = publicChoice.index === 1;
+    if (config.publicTunnel && config.password === false) {
+      console.log(yellow('  ⚠ Public tunnels require password authentication.'));
+      config.password = crypto.randomBytes(16).toString('base64url');
+      console.log(dim(`  Auto-generated password: ${config.password}`));
+    }
+  } else if (accessChoice.index === 1) {
+    // LAN mode: bind to all interfaces, no tunnel
+    config.lan = true;
+    config.noTunnel = true;
+  } else {
+    // Localhost only: no tunnel
+    config.host = '127.0.0.1';
+    config.noTunnel = true;
+  }
+  const accessLabel = config.noTunnel
+    ? config.lan
+      ? 'LAN (0.0.0.0)'
+      : 'Localhost only'
+    : config.publicTunnel
+      ? 'DevTunnel (public)'
+      : 'DevTunnel (private)';
+  decisions.push({ label: 'Access', value: accessLabel });
+
+  // Working directory
+  showProgress(4);
+  config.cwd = await ask(rl, 'Working directory:', process.cwd());
+  decisions.push({ label: 'Directory', value: config.cwd });
+
+  // Shell — use current shell automatically
+  config.shell = process.env.SHELL || (os.platform() === 'win32' ? process.env.COMSPEC : '/bin/sh');
+  decisions.push({ label: 'Shell', value: config.shell });
+
+  // Log level
+  showProgress(5);
+  const logChoice = await choose(
+    rl,
+    'Log level:',
+    [
+      { label: 'info', hint: 'Standard logging — startup, connections, errors (recommended)' },
+      { label: 'debug', hint: 'Verbose output — useful for troubleshooting issues' },
+      { label: 'warn', hint: 'Only warnings and errors' },
+      { label: 'error', hint: 'Only critical errors — minimal output' },
+    ],
+    0,
+  );
+  config.logLevel = logChoice.value;
+  decisions.push({ label: 'Log level', value: config.logLevel });
+
+  // Boot
+  showProgress(6);
+  config.startup = await confirm(rl, 'Auto-start TermBeam on system boot?', true);
+  decisions.push({ label: 'Boot', value: config.startup ? 'yes' : 'no' });
+
+  // Confirm
+  showProgress(7);
+  console.log(bold('\n── Configuration Summary ──────────────────'));
+  console.log(`  Service name:  ${cyan(config.name)}`);
+  console.log(
+    `  Password:      ${config.password === false ? yellow('disabled') : cyan(config.password)}`,
+  );
+  console.log(`  Port:          ${cyan(String(config.port))}`);
+  console.log(
+    `  Host:          ${cyan(config.lan ? '0.0.0.0 (LAN)' : config.host || '127.0.0.1')}`,
+  );
+  console.log(`  Tunnel:        ${config.noTunnel ? yellow('disabled') : cyan('enabled')}`);
+  if (!config.noTunnel) {
+    console.log(`  Persisted:     ${config.persistedTunnel ? cyan('yes') : dim('no')}`);
+    console.log(`  Public:        ${config.publicTunnel ? yellow('yes') : dim('no')}`);
+  }
+  console.log(`  Directory:     ${cyan(config.cwd)}`);
+  console.log(`  Shell:         ${cyan(config.shell || 'default')}`);
+  console.log(`  Log level:     ${cyan(config.logLevel)}`);
+  console.log(`  Boot:          ${config.startup ? cyan('yes') : dim('no')}`);
+  console.log(dim('─'.repeat(44)));
+
+  const proceed = await confirm(rl, '\nProceed with installation?', true);
+  rl.close();
+
+  // Exit alternate screen — return to normal terminal
+  exitAltScreen();
+  process.removeListener('exit', exitAltScreen);
+
+  if (!proceed) {
+    console.log(dim('Cancelled.'));
+    process.exit(0);
+  }
+
+  // Step 3: Create working directory if needed, write ecosystem & start
+  if (!fs.existsSync(config.cwd)) {
+    fs.mkdirSync(config.cwd, { recursive: true });
+    console.log(green(`✓ Created directory ${config.cwd}`));
+  }
+  const ecosystemContent = generateEcosystem(config);
+  writeEcosystem(ecosystemContent);
+  console.log(green(`\n✓ Config written to ${ECOSYSTEM_FILE}`));
+
+  // Stop existing instance if running
+  pm2Exec(['delete', config.name], { silent: true });
+
+  // Truncate old log files for a clean start
+  const outLog = path.join(os.homedir(), '.pm2', 'logs', `${config.name}-out.log`);
+  const errLog = path.join(os.homedir(), '.pm2', 'logs', `${config.name}-error.log`);
+  try {
+    fs.writeFileSync(outLog, '', 'utf8');
+  } catch {}
+  try {
+    fs.writeFileSync(errLog, '', 'utf8');
+  } catch {}
+
+  // Start
+  const started = pm2Exec(['start', ECOSYSTEM_FILE], { inherit: true });
+  if (started === null && !fs.existsSync(ECOSYSTEM_FILE)) {
+    console.error(red('✗ Failed to start TermBeam service.'));
+    process.exit(1);
+  }
+
+  pm2Exec(['save'], { inherit: true });
+  console.log(green('\n✓ TermBeam is now running as a PM2 service!'));
+
+  // Run pm2 startup if chosen during wizard
+  if (config.startup) {
+    console.log('');
+    // pm2 startup outputs a sudo command to copy/paste — capture it and run it
+    const startupOutput = pm2Exec(['startup'], { silent: true }) || '';
+    const sudoMatch = startupOutput.match(/^(sudo .+)$/m);
+    if (sudoMatch) {
+      console.log(dim('Setting up boot persistence (may ask for your password)...\n'));
+      const { spawn } = require('child_process');
+      const child = spawn('sh', ['-c', sudoMatch[1]], { stdio: 'inherit' });
+      await new Promise((resolve) => child.on('close', resolve));
+      pm2Exec(['save'], { inherit: true });
+      console.log(green('✓ TermBeam will start automatically on boot.'));
+    } else {
+      // Fallback: just show what pm2 said
+      console.log(startupOutput);
+    }
+  }
+
+  // Wait for server to start and show connection info
+  console.log(dim('\nWaiting for TermBeam to start...'));
+  const maxWait = 15;
+  let logContent = '';
+  for (let i = 0; i < maxWait; i++) {
+    await new Promise((r) => setTimeout(r, 1000));
+    try {
+      logContent = fs.readFileSync(outLog, 'utf8');
+    } catch {
+      continue;
+    }
+    if (logContent.includes('Scan the QR code') || logContent.includes('Local:')) break;
+  }
+  if (logContent) {
+    // Extract from last "Shell:" to last "Scan the QR code" line
+    const lines = logContent.split('\n');
+    const startIdx = lines.findLastIndex((l) => l.includes('Shell:'));
+    const endIdx = lines.findLastIndex((l) => l.includes('Scan the QR code'));
+    if (startIdx >= 0 && endIdx >= startIdx) {
+      console.log('');
+      for (let i = startIdx; i <= endIdx; i++) {
+        console.log(lines[i]);
+      }
+      console.log('');
+    }
+  }
+
+  console.log(dim('\nUseful commands:'));
+  console.log(`  ${cyan('termbeam service status')}   — Check service status`);
+  console.log(`  ${cyan('termbeam service logs')}     — View logs`);
+  console.log(`  ${cyan('termbeam service restart')}  — Restart service`);
+  console.log(`  ${cyan('termbeam service uninstall')} — Remove service\n`);
+}
+
+async function actionUninstall() {
+  const pm2Path = findPm2();
+  if (!pm2Path) {
+    console.error(red('✗ PM2 is not installed.'));
+    process.exit(1);
+  }
+
+  // Find running termbeam services
+  const list = pm2Exec(['jlist'], { silent: true });
+  let services = [];
+  if (list) {
+    try {
+      services = JSON.parse(list).filter(
+        (p) => p.name === DEFAULT_SERVICE_NAME || p.name.startsWith('termbeam'),
+      );
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  const name = services.length > 0 ? services[0].name : DEFAULT_SERVICE_NAME;
+
+  const rl = createRL();
+  const sure = await confirm(rl, `Remove TermBeam service "${name}" from PM2?`, true);
+  rl.close();
+
+  if (!sure) {
+    console.log(dim('Cancelled.'));
+    process.exit(0);
+  }
+
+  pm2Exec(['stop', name], { inherit: true });
+  pm2Exec(['delete', name], { inherit: true });
+  pm2Exec(['save'], { inherit: true });
+
+  // Clean up ecosystem file
+  if (fs.existsSync(ECOSYSTEM_FILE)) {
+    fs.unlinkSync(ECOSYSTEM_FILE);
+    console.log(dim(`Removed ${ECOSYSTEM_FILE}`));
+  }
+
+  console.log(green(`\n✓ TermBeam service "${name}" removed.\n`));
+}
+
+function actionStatus() {
+  const pm2Path = findPm2();
+  if (!pm2Path) {
+    console.error(red('✗ PM2 is not installed. Run: npm install -g pm2'));
+    process.exit(1);
+  }
+  pm2Exec(['describe', DEFAULT_SERVICE_NAME], { inherit: true });
+}
+
+function actionLogs() {
+  const pm2Path = findPm2();
+  if (!pm2Path) {
+    console.error(red('✗ PM2 is not installed. Run: npm install -g pm2'));
+    process.exit(1);
+  }
+  const { spawn } = require('child_process');
+  const child = spawn('pm2', ['logs', DEFAULT_SERVICE_NAME, '--lines', '200'], {
+    stdio: 'inherit',
+  });
+  child.on('error', (err) => {
+    console.error(red(`✗ Failed to stream logs: ${err.message}`));
+  });
+}
+
+function actionRestart() {
+  const pm2Path = findPm2();
+  if (!pm2Path) {
+    console.error(red('✗ PM2 is not installed. Run: npm install -g pm2'));
+    process.exit(1);
+  }
+  pm2Exec(['restart', DEFAULT_SERVICE_NAME], { inherit: true });
+  console.log(green('\n✓ TermBeam service restarted.\n'));
+}
+
+// ── readline factory ─────────────────────────────────────────────────────────
+
+function createRL() {
+  return readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+}
+
+// ── Entrypoint ───────────────────────────────────────────────────────────────
+
+function printServiceHelp() {
+  console.log(`
+${bold('termbeam service')} — Manage TermBeam as a background service (PM2)
+
+${bold('Usage:')}
+  termbeam service install     Interactive setup & start
+  termbeam service uninstall   Stop & remove from PM2
+  termbeam service status      Show service status
+  termbeam service logs        Tail service logs
+  termbeam service restart     Restart the service
+
+${dim('PM2 will be installed globally if not already present.')}
+`);
+}
+
+async function run(args) {
+  const action = (args[0] || '').toLowerCase();
+
+  switch (action) {
+    case 'install':
+      await actionInstall();
+      break;
+    case 'uninstall':
+    case 'remove':
+      await actionUninstall();
+      break;
+    case 'status':
+      actionStatus();
+      break;
+    case 'logs':
+    case 'log':
+      actionLogs();
+      break;
+    case 'restart':
+      actionRestart();
+      break;
+    default:
+      printServiceHelp();
+      break;
+  }
+}
+
+module.exports = {
+  run,
+  findPm2,
+  buildArgs,
+  generateEcosystem,
+  writeEcosystem,
+  pm2Exec,
+  actionStatus,
+  actionRestart,
+  actionLogs,
+  printServiceHelp,
+  color,
+  green,
+  yellow,
+  red,
+  cyan,
+  bold,
+  dim,
+  ask,
+  choose,
+  confirm,
+  TERMBEAM_DIR,
+  ECOSYSTEM_FILE,
+  DEFAULT_SERVICE_NAME,
+};

--- a/test/service-interactive.test.js
+++ b/test/service-interactive.test.js
@@ -1,0 +1,254 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { PassThrough } = require('stream');
+const readline = require('readline');
+
+const { ask, choose, confirm } = require('../src/service.js');
+
+function createMockRL() {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const rl = readline.createInterface({ input, output });
+  return { rl, input, output };
+}
+
+describe('ask()', () => {
+  it('returns user input when provided', async () => {
+    const { rl, input } = createMockRL();
+    const promise = ask(rl, 'Name:');
+    input.write('hello\n');
+    assert.strictEqual(await promise, 'hello');
+    rl.close();
+  });
+
+  it('returns default value when user presses Enter', async () => {
+    const { rl, input } = createMockRL();
+    const promise = ask(rl, 'Name:', 'world');
+    input.write('\n');
+    assert.strictEqual(await promise, 'world');
+    rl.close();
+  });
+
+  it('returns empty string when no default and empty input', async () => {
+    const { rl, input } = createMockRL();
+    const promise = ask(rl, 'Name:');
+    input.write('\n');
+    assert.strictEqual(await promise, '');
+    rl.close();
+  });
+
+  it('trims whitespace from input', async () => {
+    const { rl, input } = createMockRL();
+    const promise = ask(rl, 'Name:');
+    input.write('  spaced  \n');
+    assert.strictEqual(await promise, 'spaced');
+    rl.close();
+  });
+
+  it('uses default when input is only whitespace', async () => {
+    const { rl, input } = createMockRL();
+    const promise = ask(rl, 'Name:', 'fallback');
+    input.write('   \n');
+    assert.strictEqual(await promise, 'fallback');
+    rl.close();
+  });
+
+  it('converts numeric default to string', async () => {
+    const { rl, input } = createMockRL();
+    const promise = ask(rl, 'Port:', 3000);
+    input.write('\n');
+    assert.strictEqual(await promise, '3000');
+    rl.close();
+  });
+});
+
+describe('confirm()', () => {
+  it('returns true for "y"', async () => {
+    const { rl, input } = createMockRL();
+    const promise = confirm(rl, 'Continue?');
+    input.write('y\n');
+    assert.strictEqual(await promise, true);
+    rl.close();
+  });
+
+  it('returns true for "yes"', async () => {
+    const { rl, input } = createMockRL();
+    const promise = confirm(rl, 'Continue?');
+    input.write('yes\n');
+    assert.strictEqual(await promise, true);
+    rl.close();
+  });
+
+  it('returns true for "Y"', async () => {
+    const { rl, input } = createMockRL();
+    const promise = confirm(rl, 'Continue?');
+    input.write('Y\n');
+    assert.strictEqual(await promise, true);
+    rl.close();
+  });
+
+  it('returns false for "n"', async () => {
+    const { rl, input } = createMockRL();
+    const promise = confirm(rl, 'Continue?');
+    input.write('n\n');
+    assert.strictEqual(await promise, false);
+    rl.close();
+  });
+
+  it('returns false for "no"', async () => {
+    const { rl, input } = createMockRL();
+    const promise = confirm(rl, 'Continue?');
+    input.write('no\n');
+    assert.strictEqual(await promise, false);
+    rl.close();
+  });
+
+  it('returns false for "N"', async () => {
+    const { rl, input } = createMockRL();
+    const promise = confirm(rl, 'Continue?');
+    input.write('N\n');
+    assert.strictEqual(await promise, false);
+    rl.close();
+  });
+
+  it('returns defaultYes (true) on empty input', async () => {
+    const { rl, input } = createMockRL();
+    const promise = confirm(rl, 'Continue?', true);
+    input.write('\n');
+    assert.strictEqual(await promise, true);
+    rl.close();
+  });
+
+  it('returns defaultYes (false) on empty input', async () => {
+    const { rl, input } = createMockRL();
+    const promise = confirm(rl, 'Continue?', false);
+    input.write('\n');
+    assert.strictEqual(await promise, false);
+    rl.close();
+  });
+
+  it('trims whitespace before checking', async () => {
+    const { rl, input } = createMockRL();
+    const promise = confirm(rl, 'Continue?');
+    input.write('  yes  \n');
+    assert.strictEqual(await promise, true);
+    rl.close();
+  });
+});
+
+describe('choose()', () => {
+  it('selects first item on Enter with string choices', async () => {
+    const { rl } = createMockRL();
+    const promise = choose(rl, 'Pick:', ['Option A', 'Option B']);
+    await new Promise((r) => setImmediate(r));
+    process.stdin.emit('data', Buffer.from('\r'));
+    const result = await promise;
+    assert.strictEqual(result.index, 0);
+    assert.strictEqual(result.value, 'Option A');
+    rl.close();
+  });
+
+  it('selects second item with down arrow then Enter', async () => {
+    const { rl } = createMockRL();
+    const promise = choose(rl, 'Pick:', ['Option A', 'Option B']);
+    await new Promise((r) => setImmediate(r));
+    process.stdin.emit('data', Buffer.from('\x1b[B'));
+    await new Promise((r) => setImmediate(r));
+    process.stdin.emit('data', Buffer.from('\r'));
+    const result = await promise;
+    assert.strictEqual(result.index, 1);
+    assert.strictEqual(result.value, 'Option B');
+    rl.close();
+  });
+
+  it('wraps around with up arrow from first item', async () => {
+    const { rl } = createMockRL();
+    const promise = choose(rl, 'Pick:', ['A', 'B', 'C']);
+    await new Promise((r) => setImmediate(r));
+    process.stdin.emit('data', Buffer.from('\x1b[A'));
+    await new Promise((r) => setImmediate(r));
+    process.stdin.emit('data', Buffer.from('\r'));
+    const result = await promise;
+    assert.strictEqual(result.index, 2);
+    assert.strictEqual(result.value, 'C');
+    rl.close();
+  });
+
+  it('accepts {label, hint} object choices', async () => {
+    const { rl } = createMockRL();
+    const choices = [
+      { label: 'Start', hint: 'Begin process' },
+      { label: 'Stop', hint: 'End process' },
+    ];
+    const promise = choose(rl, 'Action:', choices);
+    await new Promise((r) => setImmediate(r));
+    process.stdin.emit('data', Buffer.from('\r'));
+    const result = await promise;
+    assert.strictEqual(result.index, 0);
+    assert.strictEqual(result.value, 'Start');
+    rl.close();
+  });
+
+  it('handles warn hint choices', async () => {
+    const { rl } = createMockRL();
+    const choices = [{ label: 'Risky', hint: 'May fail', warn: true }];
+    const promise = choose(rl, 'Pick:', choices);
+    await new Promise((r) => setImmediate(r));
+    process.stdin.emit('data', Buffer.from('\r'));
+    const result = await promise;
+    assert.strictEqual(result.index, 0);
+    assert.strictEqual(result.value, 'Risky');
+    rl.close();
+  });
+
+  it('handles danger hint choices', async () => {
+    const { rl } = createMockRL();
+    const choices = [{ label: 'Delete', hint: 'Permanent!', danger: true }];
+    const promise = choose(rl, 'Pick:', choices);
+    await new Promise((r) => setImmediate(r));
+    process.stdin.emit('data', Buffer.from('\r'));
+    const result = await promise;
+    assert.strictEqual(result.index, 0);
+    assert.strictEqual(result.value, 'Delete');
+    rl.close();
+  });
+
+  it('respects defaultIndex', async () => {
+    const { rl } = createMockRL();
+    const promise = choose(rl, 'Pick:', ['A', 'B', 'C'], 2);
+    await new Promise((r) => setImmediate(r));
+    process.stdin.emit('data', Buffer.from('\r'));
+    const result = await promise;
+    assert.strictEqual(result.index, 2);
+    assert.strictEqual(result.value, 'C');
+    rl.close();
+  });
+
+  it('navigates with j/k keys', async () => {
+    const { rl } = createMockRL();
+    const promise = choose(rl, 'Pick:', ['A', 'B', 'C']);
+    await new Promise((r) => setImmediate(r));
+    process.stdin.emit('data', Buffer.from('j'));
+    await new Promise((r) => setImmediate(r));
+    process.stdin.emit('data', Buffer.from('j'));
+    await new Promise((r) => setImmediate(r));
+    process.stdin.emit('data', Buffer.from('k'));
+    await new Promise((r) => setImmediate(r));
+    process.stdin.emit('data', Buffer.from('\r'));
+    const result = await promise;
+    assert.strictEqual(result.index, 1);
+    assert.strictEqual(result.value, 'B');
+    rl.close();
+  });
+
+  it('accepts newline as Enter', async () => {
+    const { rl } = createMockRL();
+    const promise = choose(rl, 'Pick:', ['Only']);
+    await new Promise((r) => setImmediate(r));
+    process.stdin.emit('data', Buffer.from('\n'));
+    const result = await promise;
+    assert.strictEqual(result.index, 0);
+    assert.strictEqual(result.value, 'Only');
+    rl.close();
+  });
+});

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -1,0 +1,1085 @@
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// We test the pure/exported functions — not the interactive prompts
+const {
+  buildArgs,
+  generateEcosystem,
+  findPm2,
+  TERMBEAM_DIR,
+  DEFAULT_SERVICE_NAME,
+} = require('../src/service');
+
+describe('service', () => {
+  describe('buildArgs', () => {
+    it('returns empty array for default config', () => {
+      const args = buildArgs({});
+      assert.deepStrictEqual(args, []);
+    });
+
+    it('adds --no-password when password is false', () => {
+      const args = buildArgs({ password: false });
+      assert.ok(args.includes('--no-password'));
+    });
+
+    it('adds --password with value when set', () => {
+      const args = buildArgs({ password: 'secret123' });
+      const idx = args.indexOf('--password');
+      assert.ok(idx >= 0);
+      assert.strictEqual(args[idx + 1], 'secret123');
+    });
+
+    it('adds --port when non-default', () => {
+      const args = buildArgs({ port: 8080 });
+      const idx = args.indexOf('--port');
+      assert.ok(idx >= 0);
+      assert.strictEqual(args[idx + 1], '8080');
+    });
+
+    it('does not add --port for default 3456', () => {
+      const args = buildArgs({ port: 3456 });
+      assert.ok(!args.includes('--port'));
+    });
+
+    it('adds --host when non-default', () => {
+      const args = buildArgs({ host: '192.168.1.1' });
+      const idx = args.indexOf('--host');
+      assert.ok(idx >= 0);
+      assert.strictEqual(args[idx + 1], '192.168.1.1');
+    });
+
+    it('adds --lan flag', () => {
+      const args = buildArgs({ lan: true });
+      assert.ok(args.includes('--lan'));
+    });
+
+    it('adds --no-tunnel flag', () => {
+      const args = buildArgs({ noTunnel: true });
+      assert.ok(args.includes('--no-tunnel'));
+    });
+
+    it('adds --persisted-tunnel flag', () => {
+      const args = buildArgs({ persistedTunnel: true });
+      assert.ok(args.includes('--persisted-tunnel'));
+    });
+
+    it('adds --public flag', () => {
+      const args = buildArgs({ publicTunnel: true });
+      assert.ok(args.includes('--public'));
+    });
+
+    it('adds --log-level when non-default', () => {
+      const args = buildArgs({ logLevel: 'debug' });
+      const idx = args.indexOf('--log-level');
+      assert.ok(idx >= 0);
+      assert.strictEqual(args[idx + 1], 'debug');
+    });
+
+    it('does not add --log-level for default info', () => {
+      const args = buildArgs({ logLevel: 'info' });
+      assert.ok(!args.includes('--log-level'));
+    });
+
+    it('adds shell as last arg', () => {
+      const args = buildArgs({ shell: '/bin/zsh' });
+      assert.strictEqual(args[args.length - 1], '/bin/zsh');
+    });
+
+    it('combines multiple flags', () => {
+      const args = buildArgs({
+        password: 'pw',
+        port: 9999,
+        lan: true,
+        noTunnel: true,
+        logLevel: 'debug',
+        shell: '/bin/bash',
+      });
+      assert.ok(args.includes('--password'));
+      assert.ok(args.includes('--port'));
+      assert.ok(args.includes('--lan'));
+      assert.ok(args.includes('--no-tunnel'));
+      assert.ok(args.includes('--log-level'));
+      assert.ok(args.includes('/bin/bash'));
+    });
+  });
+
+  describe('generateEcosystem', () => {
+    it('generates valid JS module content', () => {
+      const content = generateEcosystem({ name: 'test-tb', port: 3456 });
+      assert.ok(content.startsWith('module.exports = '));
+      assert.ok(content.includes('"test-tb"'));
+    });
+
+    it('includes termbeam.js script path', () => {
+      const content = generateEcosystem({ name: 'termbeam' });
+      assert.ok(content.includes('termbeam.js'));
+    });
+
+    it('uses default name when not specified', () => {
+      const content = generateEcosystem({});
+      assert.ok(content.includes(`"${DEFAULT_SERVICE_NAME}"`));
+    });
+
+    it('sets cwd in ecosystem config', () => {
+      const content = generateEcosystem({ cwd: '/tmp/mydir' });
+      assert.ok(content.includes('/tmp/mydir'));
+    });
+
+    it('includes args from buildArgs', () => {
+      const content = generateEcosystem({ password: 'test', noTunnel: true });
+      assert.ok(content.includes('"--password"'));
+      assert.ok(content.includes('"test"'));
+      assert.ok(content.includes('"--no-tunnel"'));
+    });
+
+    it('sets autorestart to true', () => {
+      const content = generateEcosystem({});
+      assert.ok(content.includes('"autorestart": true'));
+    });
+  });
+
+  describe('findPm2', () => {
+    it('returns a string or null', () => {
+      const result = findPm2();
+      assert.ok(result === null || typeof result === 'string');
+    });
+  });
+
+  describe('constants', () => {
+    it('TERMBEAM_DIR is under home directory', () => {
+      assert.ok(TERMBEAM_DIR.startsWith(os.homedir()));
+      assert.ok(TERMBEAM_DIR.endsWith('.termbeam'));
+    });
+
+    it('DEFAULT_SERVICE_NAME is termbeam', () => {
+      assert.strictEqual(DEFAULT_SERVICE_NAME, 'termbeam');
+    });
+  });
+});
+
+// ── Mock helper for testing internal functions with mocked dependencies ──────
+
+const Module = require('module');
+
+function loadServiceWithMocks(mocks = {}) {
+  const originalLoad = Module._load;
+  const servicePath = require.resolve('../src/service');
+
+  delete require.cache[servicePath];
+
+  const mockModules = {};
+  if (mocks.childProcess) {
+    mockModules['child_process'] = { ...require('child_process'), ...mocks.childProcess };
+  }
+  if (mocks.fs) {
+    mockModules['fs'] = { ...require('fs'), ...mocks.fs };
+  }
+  if (mocks.readline) {
+    mockModules['readline'] = { ...require('readline'), ...mocks.readline };
+  }
+
+  Module._load = function (request, parent, isMain) {
+    if (mockModules[request] && parent && parent.filename === servicePath) {
+      return mockModules[request];
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  const service = require('../src/service');
+
+  return {
+    service,
+    restore() {
+      delete require.cache[servicePath];
+      Module._load = originalLoad;
+    },
+  };
+}
+
+describe('color helpers', () => {
+  const svc = require('../src/service');
+
+  it('green wraps text with ANSI green code', () => {
+    assert.strictEqual(svc.green('hi'), '\x1b[32mhi\x1b[0m');
+  });
+
+  it('yellow wraps text with ANSI yellow code', () => {
+    assert.strictEqual(svc.yellow('hi'), '\x1b[33mhi\x1b[0m');
+  });
+
+  it('red wraps text with ANSI red code', () => {
+    assert.strictEqual(svc.red('hi'), '\x1b[31mhi\x1b[0m');
+  });
+
+  it('cyan wraps text with ANSI cyan code', () => {
+    assert.strictEqual(svc.cyan('hi'), '\x1b[36mhi\x1b[0m');
+  });
+
+  it('bold wraps text with ANSI bold code', () => {
+    assert.strictEqual(svc.bold('hi'), '\x1b[1mhi\x1b[0m');
+  });
+
+  it('dim wraps text with ANSI dim code', () => {
+    assert.strictEqual(svc.dim('hi'), '\x1b[2mhi\x1b[0m');
+  });
+
+  it('color wraps text with arbitrary ANSI code', () => {
+    assert.strictEqual(svc.color('42', 'bg'), '\x1b[42mbg\x1b[0m');
+  });
+});
+
+describe('writeEcosystem', () => {
+  let loaded;
+
+  afterEach(() => {
+    if (loaded) loaded.restore();
+  });
+
+  it('creates directory and writes ecosystem file', () => {
+    const calls = { mkdir: [], writeFile: [] };
+    loaded = loadServiceWithMocks({
+      fs: {
+        mkdirSync: (...args) => calls.mkdir.push(args),
+        writeFileSync: (...args) => calls.writeFile.push(args),
+      },
+    });
+
+    loaded.service.writeEcosystem('test content');
+
+    assert.strictEqual(calls.mkdir.length, 1);
+    assert.ok(calls.mkdir[0][0].endsWith('.termbeam'));
+    assert.deepStrictEqual(calls.mkdir[0][1], { recursive: true });
+
+    assert.strictEqual(calls.writeFile.length, 1);
+    assert.ok(calls.writeFile[0][0].endsWith('ecosystem.config.js'));
+    assert.strictEqual(calls.writeFile[0][1], 'test content');
+    assert.strictEqual(calls.writeFile[0][2], 'utf8');
+  });
+});
+
+describe('pm2Exec', () => {
+  let loaded;
+
+  afterEach(() => {
+    if (loaded) loaded.restore();
+  });
+
+  it('returns stdout on success', () => {
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: () => 'pm2 output',
+      },
+    });
+    const result = loaded.service.pm2Exec(['list']);
+    assert.strictEqual(result, 'pm2 output');
+  });
+
+  it('returns null on error with silent: true', () => {
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: () => {
+          throw new Error('command failed');
+        },
+      },
+    });
+    const result = loaded.service.pm2Exec(['list'], { silent: true });
+    assert.strictEqual(result, null);
+  });
+
+  it('logs error on failure without silent', () => {
+    const errors = [];
+    const origError = console.error;
+    console.error = (...args) => errors.push(args.join(' '));
+
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: () => {
+          const err = new Error('fail');
+          err.stderr = 'some stderr output';
+          throw err;
+        },
+      },
+    });
+
+    const result = loaded.service.pm2Exec(['describe', 'termbeam']);
+    console.error = origError;
+
+    assert.strictEqual(result, null);
+    assert.ok(errors.some((e) => e.includes('PM2 command failed')));
+    assert.ok(errors.some((e) => e.includes('some stderr output')));
+  });
+
+  it('uses inherit stdio when opts.inherit is true', () => {
+    let capturedOpts;
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd, args, opts) => {
+          capturedOpts = opts;
+          return '';
+        },
+      },
+    });
+    loaded.service.pm2Exec(['list'], { inherit: true });
+    assert.strictEqual(capturedOpts.stdio, 'inherit');
+  });
+});
+
+describe('actionStatus', () => {
+  let loaded;
+  let origExit, origError;
+  let exitCode;
+
+  beforeEach(() => {
+    origExit = process.exit;
+    origError = console.error;
+    exitCode = null;
+    process.exit = (code) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    };
+    console.error = () => {};
+  });
+
+  afterEach(() => {
+    process.exit = origExit;
+    console.error = origError;
+    if (loaded) loaded.restore();
+  });
+
+  it('calls pm2 describe when PM2 is found', () => {
+    const calls = [];
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd, args) => {
+          calls.push({ cmd, args });
+          if (cmd === 'which' || cmd === 'where') return '/usr/bin/pm2\n';
+          return '';
+        },
+      },
+    });
+
+    loaded.service.actionStatus();
+
+    const pm2Call = calls.find((c) => c.cmd === 'pm2');
+    assert.ok(pm2Call, 'pm2 should have been called');
+    assert.deepStrictEqual(pm2Call.args, ['describe', 'termbeam']);
+  });
+
+  it('exits with error when PM2 is not found', () => {
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: () => {
+          throw new Error('not found');
+        },
+      },
+    });
+
+    assert.throws(() => loaded.service.actionStatus(), /process\.exit/);
+    assert.strictEqual(exitCode, 1);
+  });
+});
+
+describe('actionRestart', () => {
+  let loaded;
+  let origExit, origLog, origError;
+  let exitCode;
+
+  beforeEach(() => {
+    origExit = process.exit;
+    origLog = console.log;
+    origError = console.error;
+    exitCode = null;
+    process.exit = (code) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    };
+    console.log = () => {};
+    console.error = () => {};
+  });
+
+  afterEach(() => {
+    process.exit = origExit;
+    console.log = origLog;
+    console.error = origError;
+    if (loaded) loaded.restore();
+  });
+
+  it('calls pm2 restart when PM2 is found', () => {
+    const calls = [];
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd, args) => {
+          calls.push({ cmd, args });
+          if (cmd === 'which' || cmd === 'where') return '/usr/bin/pm2\n';
+          return '';
+        },
+      },
+    });
+
+    loaded.service.actionRestart();
+
+    const pm2Call = calls.find((c) => c.cmd === 'pm2');
+    assert.ok(pm2Call, 'pm2 should have been called');
+    assert.deepStrictEqual(pm2Call.args, ['restart', 'termbeam']);
+  });
+
+  it('exits with error when PM2 is not found', () => {
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: () => {
+          throw new Error('not found');
+        },
+      },
+    });
+
+    assert.throws(() => loaded.service.actionRestart(), /process\.exit/);
+    assert.strictEqual(exitCode, 1);
+  });
+});
+
+describe('actionLogs', () => {
+  let loaded;
+  let origExit, origError;
+
+  beforeEach(() => {
+    origExit = process.exit;
+    origError = console.error;
+    process.exit = (code) => {
+      throw new Error(`process.exit(${code})`);
+    };
+    console.error = () => {};
+  });
+
+  afterEach(() => {
+    process.exit = origExit;
+    console.error = origError;
+    if (loaded) loaded.restore();
+  });
+
+  it('spawns pm2 logs with correct arguments', () => {
+    const spawnCalls = [];
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd) => {
+          if (cmd === 'which' || cmd === 'where') return '/usr/bin/pm2\n';
+          return '';
+        },
+        spawn: (cmd, args, opts) => {
+          spawnCalls.push({ cmd, args, opts });
+          return { on: () => {} };
+        },
+      },
+    });
+
+    loaded.service.actionLogs();
+
+    assert.strictEqual(spawnCalls.length, 1);
+    assert.strictEqual(spawnCalls[0].cmd, 'pm2');
+    assert.deepStrictEqual(spawnCalls[0].args, ['logs', 'termbeam', '--lines', '200']);
+    assert.deepStrictEqual(spawnCalls[0].opts, { stdio: 'inherit' });
+  });
+
+  it('exits with error when PM2 is not found', () => {
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: () => {
+          throw new Error('not found');
+        },
+      },
+    });
+
+    assert.throws(() => loaded.service.actionLogs(), /process\.exit/);
+  });
+});
+
+describe('run', () => {
+  let loaded;
+  let origExit, origLog, origError;
+  let logs;
+
+  beforeEach(() => {
+    origExit = process.exit;
+    origLog = console.log;
+    origError = console.error;
+    logs = [];
+    process.exit = (code) => {
+      throw new Error(`process.exit(${code})`);
+    };
+    console.log = (...args) => logs.push(args.join(' '));
+    console.error = () => {};
+  });
+
+  afterEach(() => {
+    process.exit = origExit;
+    console.log = origLog;
+    console.error = origError;
+    if (loaded) loaded.restore();
+  });
+
+  it('status calls actionStatus', async () => {
+    const calls = [];
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd, args) => {
+          calls.push({ cmd, args });
+          if (cmd === 'which' || cmd === 'where') return '/usr/bin/pm2\n';
+          return '';
+        },
+      },
+    });
+    await loaded.service.run(['status']);
+    assert.ok(calls.some((c) => c.cmd === 'pm2' && c.args[0] === 'describe'));
+  });
+
+  it('restart calls actionRestart', async () => {
+    const calls = [];
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd, args) => {
+          calls.push({ cmd, args });
+          if (cmd === 'which' || cmd === 'where') return '/usr/bin/pm2\n';
+          return '';
+        },
+      },
+    });
+    await loaded.service.run(['restart']);
+    assert.ok(calls.some((c) => c.cmd === 'pm2' && c.args[0] === 'restart'));
+  });
+
+  it('logs calls actionLogs', async () => {
+    const spawnCalls = [];
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd) => {
+          if (cmd === 'which' || cmd === 'where') return '/usr/bin/pm2\n';
+          return '';
+        },
+        spawn: (cmd, args) => {
+          spawnCalls.push({ cmd, args });
+          return { on: () => {} };
+        },
+      },
+    });
+    await loaded.service.run(['logs']);
+    assert.ok(spawnCalls.some((c) => c.cmd === 'pm2' && c.args[0] === 'logs'));
+  });
+
+  it('log also calls actionLogs', async () => {
+    const spawnCalls = [];
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd) => {
+          if (cmd === 'which' || cmd === 'where') return '/usr/bin/pm2\n';
+          return '';
+        },
+        spawn: (cmd, args) => {
+          spawnCalls.push({ cmd, args });
+          return { on: () => {} };
+        },
+      },
+    });
+    await loaded.service.run(['log']);
+    assert.ok(spawnCalls.some((c) => c.cmd === 'pm2' && c.args[0] === 'logs'));
+  });
+
+  it('unknown action prints help', async () => {
+    loaded = loadServiceWithMocks();
+    await loaded.service.run(['unknown-action']);
+    assert.ok(logs.some((l) => l.includes('termbeam service')));
+  });
+
+  it('empty args prints help', async () => {
+    loaded = loadServiceWithMocks();
+    await loaded.service.run([]);
+    assert.ok(logs.some((l) => l.includes('termbeam service')));
+  });
+
+  it('install calls actionInstall', async () => {
+    const execCalls = [];
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd, args) => {
+          execCalls.push({ cmd, args });
+          throw new Error('not found');
+        },
+      },
+      readline: {
+        createInterface: () => ({
+          question: (q, cb) => cb('n'),
+          close: () => {},
+        }),
+      },
+    });
+    await assert.rejects(() => loaded.service.run(['install']), /process\.exit/);
+    assert.ok(execCalls.some((c) => c.args && c.args[0] === 'pm2'));
+  });
+
+  it('uninstall calls actionUninstall', async () => {
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: () => {
+          throw new Error('not found');
+        },
+      },
+    });
+    await assert.rejects(() => loaded.service.run(['uninstall']), /process\.exit/);
+  });
+
+  it('remove also calls actionUninstall', async () => {
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: () => {
+          throw new Error('not found');
+        },
+      },
+    });
+    await assert.rejects(() => loaded.service.run(['remove']), /process\.exit/);
+  });
+});
+
+// ── installPm2Global tests ──────────────────────────────────────────────────
+
+describe('installPm2Global (via run install)', () => {
+  let loaded;
+  let origExit, origLog, origError;
+  let exitCode;
+
+  beforeEach(() => {
+    origExit = process.exit;
+    origLog = console.log;
+    origError = console.error;
+    exitCode = null;
+    process.exit = (code) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    };
+    console.log = () => {};
+    console.error = () => {};
+  });
+
+  afterEach(() => {
+    process.exit = origExit;
+    console.log = origLog;
+    console.error = origError;
+    if (loaded) loaded.restore();
+  });
+
+  it('exits when npm install -g pm2 fails', async () => {
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd) => {
+          if (cmd === 'which' || cmd === 'where') throw new Error('not found');
+          if (cmd === 'npm') throw new Error('permission denied');
+          return '';
+        },
+      },
+      readline: {
+        createInterface: () => ({
+          question: (prompt, cb) => setImmediate(() => cb('y')),
+          close: () => {},
+        }),
+      },
+    });
+    await assert.rejects(() => loaded.service.run(['install']), /process\.exit/);
+    assert.strictEqual(exitCode, 1);
+  });
+
+  it('exits when PM2 still not found after successful install', async () => {
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd) => {
+          if (cmd === 'which' || cmd === 'where') throw new Error('not found');
+          if (cmd === 'npm') return '';
+          return '';
+        },
+      },
+      readline: {
+        createInterface: () => ({
+          question: (prompt, cb) => setImmediate(() => cb('y')),
+          close: () => {},
+        }),
+      },
+    });
+    await assert.rejects(() => loaded.service.run(['install']), /process\.exit/);
+    assert.strictEqual(exitCode, 1);
+  });
+});
+
+// ── actionUninstall tests ───────────────────────────────────────────────────
+
+describe('actionUninstall (via run)', () => {
+  let loaded;
+  let origExit, origLog, origError;
+  let exitCode;
+
+  beforeEach(() => {
+    origExit = process.exit;
+    origLog = console.log;
+    origError = console.error;
+    exitCode = null;
+    process.exit = (code) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    };
+    console.log = () => {};
+    console.error = () => {};
+  });
+
+  afterEach(() => {
+    process.exit = origExit;
+    console.log = origLog;
+    console.error = origError;
+    if (loaded) loaded.restore();
+  });
+
+  it('stops, deletes, saves, and removes ecosystem when user confirms', async () => {
+    const execCalls = [];
+    const unlinkCalls = [];
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd, args) => {
+          execCalls.push({ cmd, args: [...(args || [])] });
+          if (cmd === 'which' || cmd === 'where') return '/usr/bin/pm2\n';
+          if (cmd === 'pm2' && args[0] === 'jlist') {
+            return JSON.stringify([{ name: 'termbeam', pm_id: 0 }]);
+          }
+          return '';
+        },
+      },
+      readline: {
+        createInterface: () => ({
+          question: (prompt, cb) => setImmediate(() => cb('y')),
+          close: () => {},
+        }),
+      },
+      fs: {
+        existsSync: () => true,
+        unlinkSync: (p) => unlinkCalls.push(p),
+      },
+    });
+
+    await loaded.service.run(['remove']);
+    assert.ok(execCalls.some((c) => c.cmd === 'pm2' && c.args[0] === 'stop'));
+    assert.ok(execCalls.some((c) => c.cmd === 'pm2' && c.args[0] === 'delete'));
+    assert.ok(execCalls.some((c) => c.cmd === 'pm2' && c.args[0] === 'save'));
+    assert.strictEqual(unlinkCalls.length, 1);
+  });
+
+  it('cancels when user declines confirmation', async () => {
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd, args) => {
+          if (cmd === 'which' || cmd === 'where') return '/usr/bin/pm2\n';
+          if (cmd === 'pm2' && args[0] === 'jlist') return '[]';
+          return '';
+        },
+      },
+      readline: {
+        createInterface: () => ({
+          question: (prompt, cb) => setImmediate(() => cb('n')),
+          close: () => {},
+        }),
+      },
+    });
+    await assert.rejects(() => loaded.service.run(['uninstall']), /process\.exit/);
+    assert.strictEqual(exitCode, 0);
+  });
+
+  it('handles invalid jlist JSON gracefully', async () => {
+    const execCalls = [];
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd, args) => {
+          execCalls.push({ cmd, args: [...(args || [])] });
+          if (cmd === 'which' || cmd === 'where') return '/usr/bin/pm2\n';
+          if (cmd === 'pm2' && args[0] === 'jlist') return 'not-json';
+          return '';
+        },
+      },
+      readline: {
+        createInterface: () => ({
+          question: (prompt, cb) => setImmediate(() => cb('y')),
+          close: () => {},
+        }),
+      },
+      fs: {
+        existsSync: () => false,
+        unlinkSync: () => {},
+      },
+    });
+    await loaded.service.run(['uninstall']);
+    assert.ok(execCalls.some((c) => c.cmd === 'pm2' && c.args[0] === 'stop'));
+  });
+
+  it('skips ecosystem removal when file does not exist', async () => {
+    const unlinkCalls = [];
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd, args) => {
+          if (cmd === 'which' || cmd === 'where') return '/usr/bin/pm2\n';
+          if (cmd === 'pm2' && args[0] === 'jlist') return '[]';
+          return '';
+        },
+      },
+      readline: {
+        createInterface: () => ({
+          question: (prompt, cb) => setImmediate(() => cb('y')),
+          close: () => {},
+        }),
+      },
+      fs: {
+        existsSync: () => false,
+        unlinkSync: (p) => unlinkCalls.push(p),
+      },
+    });
+    await loaded.service.run(['uninstall']);
+    assert.strictEqual(unlinkCalls.length, 0);
+  });
+});
+
+// ── actionLogs error handler ────────────────────────────────────────────────
+
+describe('actionLogs error handler', () => {
+  let loaded;
+  let origExit, origError;
+
+  beforeEach(() => {
+    origExit = process.exit;
+    origError = console.error;
+    process.exit = (code) => {
+      throw new Error(`process.exit(${code})`);
+    };
+  });
+
+  afterEach(() => {
+    process.exit = origExit;
+    console.error = origError;
+    if (loaded) loaded.restore();
+  });
+
+  it('logs error when spawn emits error event', async () => {
+    const errors = [];
+    console.error = (...args) => errors.push(args.join(' '));
+
+    loaded = loadServiceWithMocks({
+      childProcess: {
+        execFileSync: (cmd) => {
+          if (cmd === 'which' || cmd === 'where') return '/usr/bin/pm2\n';
+          return '';
+        },
+        spawn: () => {
+          const { EventEmitter } = require('events');
+          const child = new EventEmitter();
+          setImmediate(() => child.emit('error', new Error('spawn ENOENT')));
+          return child;
+        },
+      },
+    });
+
+    loaded.service.actionLogs();
+    await new Promise((r) => setTimeout(r, 50));
+    assert.ok(errors.some((e) => e.includes('Failed to stream logs')));
+  });
+});
+
+// ── actionInstall wizard tests ──────────────────────────────────────────────
+
+describe('actionInstall wizard (via run)', () => {
+  let loaded;
+  let origExit, origLog, origError;
+  let exitCode;
+
+  beforeEach(() => {
+    origExit = process.exit;
+    origLog = console.log;
+    origError = console.error;
+    exitCode = null;
+    process.exit = (code) => {
+      exitCode = code;
+      throw new Error(`process.exit(${code})`);
+    };
+    console.log = () => {};
+    console.error = () => {};
+  });
+
+  afterEach(() => {
+    process.exit = origExit;
+    console.log = origLog;
+    console.error = origError;
+    if (loaded) loaded.restore();
+  });
+
+  function wizardMocks({
+    questionAnswers,
+    chooseIndices = [],
+    execOverride,
+    fsMock,
+    startupOutput = '',
+    spawnMock,
+  }) {
+    let qIdx = 0;
+    let cIdx = 0;
+    return {
+      childProcess: {
+        execFileSync:
+          execOverride ||
+          ((cmd, args) => {
+            if (cmd === 'which' || cmd === 'where') return '/usr/bin/pm2\n';
+            if (cmd === 'pm2' && args[0] === 'startup') return startupOutput;
+            return '';
+          }),
+        spawn:
+          spawnMock ||
+          (() => ({
+            on: (event, cb) => {
+              if (event === 'close') setImmediate(cb);
+            },
+          })),
+      },
+      readline: {
+        createInterface: () => ({
+          question: (prompt, cb) => {
+            const ans = questionAnswers[qIdx++] || '';
+            setImmediate(() => cb(ans));
+          },
+          close: () => {},
+          pause: () => {
+            const idx = chooseIndices[cIdx++] || 0;
+            setImmediate(() => {
+              for (let i = 0; i < idx; i++) {
+                process.stdin.emit('data', Buffer.from('\x1b[B'));
+              }
+              process.stdin.emit('data', Buffer.from('\r'));
+            });
+          },
+          resume: () => {},
+        }),
+      },
+      fs: fsMock || {
+        existsSync: () => true,
+        mkdirSync: () => {},
+        writeFileSync: () => {},
+        readFileSync: () => 'Shell: /bin/bash\nLocal: http://localhost:3456\nScan the QR code',
+        unlinkSync: () => {},
+      },
+    };
+  }
+
+  it('completes DevTunnel install with sudo startup', async () => {
+    const mocks = wizardMocks({
+      questionAnswers: ['myservice', '4000', '/tmp/testdir', 'y', 'y'],
+      chooseIndices: [0, 0, 0, 0],
+      startupOutput: 'sudo env PATH=$PATH pm2 startup systemd',
+    });
+    loaded = loadServiceWithMocks(mocks);
+    await loaded.service.run(['install']);
+  });
+
+  it('completes LAN install without tunnel sub-question', async () => {
+    const mocks = wizardMocks({
+      questionAnswers: ['lansvc', '3456', '/tmp/lan', 'n', 'y'],
+      chooseIndices: [0, 1, 0],
+    });
+    loaded = loadServiceWithMocks(mocks);
+    await loaded.service.run(['install']);
+  });
+
+  it('completes localhost-only install', async () => {
+    const mocks = wizardMocks({
+      questionAnswers: ['localsvc', '5000', '/tmp/local', 'y', 'y'],
+      chooseIndices: [0, 2, 0],
+      startupOutput: 'pm2 startup configured',
+    });
+    loaded = loadServiceWithMocks(mocks);
+    await loaded.service.run(['install']);
+  });
+
+  it('exits when user cancels at confirmation', async () => {
+    const mocks = wizardMocks({
+      questionAnswers: ['cancelsvc', '3456', '/tmp/cancel', 'y', 'n'],
+      chooseIndices: [0, 0, 0, 0],
+    });
+    loaded = loadServiceWithMocks(mocks);
+    await assert.rejects(() => loaded.service.run(['install']), /process\.exit/);
+    assert.strictEqual(exitCode, 0);
+  });
+
+  it('handles custom password flow', async () => {
+    const mocks = wizardMocks({
+      questionAnswers: ['customsvc', 'mypassword', '3456', '/tmp/custom', 'n', 'y'],
+      chooseIndices: [1, 2, 0],
+    });
+    loaded = loadServiceWithMocks(mocks);
+    await loaded.service.run(['install']);
+  });
+
+  it('retries when custom password is empty', async () => {
+    const mocks = wizardMocks({
+      questionAnswers: ['retrysvc', '', 'actualpassword', '3456', '/tmp/retry', 'n', 'y'],
+      chooseIndices: [1, 2, 0],
+    });
+    loaded = loadServiceWithMocks(mocks);
+    await loaded.service.run(['install']);
+  });
+
+  it('handles no-password choice', async () => {
+    const mocks = wizardMocks({
+      questionAnswers: ['nopwsvc', '3456', '/tmp/nopw', 'n', 'y'],
+      chooseIndices: [2, 2, 0],
+    });
+    loaded = loadServiceWithMocks(mocks);
+    await loaded.service.run(['install']);
+  });
+
+  it('auto-generates password for no-password with public tunnel', async () => {
+    const mocks = wizardMocks({
+      questionAnswers: ['publicsvc', '3456', '/tmp/public', 'n', 'y'],
+      chooseIndices: [2, 0, 1, 0],
+    });
+    loaded = loadServiceWithMocks(mocks);
+    await loaded.service.run(['install']);
+  });
+
+  it('creates working directory when it does not exist', async () => {
+    const mkdirCalls = [];
+    const mocks = wizardMocks({
+      questionAnswers: ['mkdirsvc', '3456', '/tmp/newdir', 'n', 'y'],
+      chooseIndices: [0, 2, 0],
+      fsMock: {
+        existsSync: (p) => !p.includes('newdir'),
+        mkdirSync: (p, opts) => mkdirCalls.push({ p, opts }),
+        writeFileSync: () => {},
+        readFileSync: () => 'Local: http://localhost:3456\nScan the QR code',
+        unlinkSync: () => {},
+      },
+    });
+    loaded = loadServiceWithMocks(mocks);
+    await loaded.service.run(['install']);
+    assert.ok(mkdirCalls.some((c) => c.p.includes('newdir')));
+  });
+
+  it('exits when pm2 start fails and ecosystem file missing', async () => {
+    const mocks = wizardMocks({
+      questionAnswers: ['failsvc', '3456', '/tmp/fail', 'n', 'y'],
+      chooseIndices: [0, 2, 0],
+      execOverride: (cmd, args) => {
+        if (cmd === 'which' || cmd === 'where') return '/usr/bin/pm2\n';
+        if (cmd === 'pm2' && args[0] === 'start') throw new Error('start failed');
+        return '';
+      },
+      fsMock: {
+        existsSync: (p) => !p.includes('ecosystem'),
+        mkdirSync: () => {},
+        writeFileSync: () => {},
+        readFileSync: () => '',
+        unlinkSync: () => {},
+      },
+    });
+    loaded = loadServiceWithMocks(mocks);
+    await assert.rejects(() => loaded.service.run(['install']), /process\.exit/);
+    assert.strictEqual(exitCode, 1);
+  });
+});


### PR DESCRIPTION
## Summary

Add `termbeam service` subcommand with a fully interactive wizard for installing and managing TermBeam as a PM2 background service.

### ✨ New Features

**PM2 Service Wizard** (`termbeam service install`)
- Interactive setup with arrow-key navigation, progress bar, and live configuration preview
- Configures: service name, password, port, access mode (DevTunnel/LAN/localhost), working directory, log level, and boot persistence
- Auto-detects PM2 and offers to install it globally if missing
- Runs `pm2 startup` automatically for boot persistence
- Shows QR code + connection URL after install for immediate use

**Service Lifecycle Commands**
- `termbeam service status` — PM2 process details
- `termbeam service logs` — tail service logs
- `termbeam service restart` — restart service
- `termbeam service uninstall` — remove from PM2 with cleanup

**Login Page Redesign**
- Matches app theme with CSS variables (dark/light mode)
- Theme toggle with localStorage persistence
- Blue accent button, proper TermBeam branding, mobile-optimized

**Responsive Terminal Font**
- Default font size adapts to screen width (12px mobile → 15px desktop)
- User's saved preference in localStorage takes priority

### 📊 Test Coverage

| Metric | Before | After |
|--------|--------|-------|
| Tests | 257 | 325 |
| Coverage | ~93% | 95.24% |
| service.js | 0% (new) | 98.76% |

### 📝 Documentation

- Enhanced `docs/running-in-background.md` with full wizard walkthrough
- Added Subcommands section to `docs/configuration.md`
- Added "Running as a Service" to `docs/getting-started.md`
- Updated README CLI reference

### Files Changed

| File | Change |
|------|--------|
| `src/service.js` | **New** — Interactive PM2 service manager (~700 lines) |
| `test/service.test.js` | **New** — 67 unit tests |
| `test/service-interactive.test.js` | **New** — 24 interactive prompt tests |
| `bin/termbeam.js` | Subcommand dispatch + PM2-compatible server start |
| `src/server.js` | Simplified auto-start guard |
| `src/auth.js` | Login page redesign |
| `src/cli.js` | Service subcommand help text |
| `public/terminal.html` | Responsive default font size |
| `docs/*.md`, `README.md` | Documentation updates |
