### PR TITLE
fix: make HTML tag filtering regexp case-insensitive

### DIFF
--- a/test/snapshot.test.js
+++ b/test/snapshot.test.js
@@ -56,13 +56,13 @@ const PUBLIC_DIR = path.join(__dirname, '..', 'public');
 function collectAllJS(html) {
   let allJS = '';
   // Inline scripts
-  const inlineRegex = /<script>([\s\S]*?)<\/script>/g;
+  const inlineRegex = /<script>([\s\S]*?)<\/script>/gi;
   let m;
   while ((m = inlineRegex.exec(html))) {
     allJS += m[1] + '\n';
   }
   // Local script src files (skip CDN)
-  const srcRegex = /<script\s+src="([^"]+)"/g;
+  const srcRegex = /<script\s+src="([^"]+)"/gi;
   while ((m = srcRegex.exec(html))) {
     const src = m[1];
     if (src.startsWith('/') && !src.startsWith('//')) {


### PR DESCRIPTION
## Summary
Adds the `i` flag to HTML script tag regexes in snapshot tests to properly match upper-case `<SCRIPT>` tags.

## Changes
- `test/snapshot.test.js`: Add case-insensitive flag to `inlineRegex` and `srcRegex`

## Code Scanning Alert Addressed
- **Alert #13** — `js/bad-tag-filter` (High) in `test/snapshot.test.js:59`

Fixes #89