### PR TITLE
fix: harden CI/CD workflow permissions and pin dependencies

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,13 +9,15 @@ on:
     - cron: '0 6 * * 1' # Weekly on Monday at 6 AM UTC
 
 permissions:
-  security-events: write
   contents: read
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -7,6 +7,9 @@ on:
       - landing/**
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,18 +20,18 @@ jobs:
       security-events: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@3b054500189c7b3ca9be7cd4f035ca58c00776cd # v3
         with:
           sarif_file: results.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim
+FROM node:22-slim@sha256:dd9d21971ec4395903fa6143c2b9267d048ae01ca6d3ea96f16cb30df6187d94
 
 RUN apt-get update && apt-get install -y \
     python3 make g++ \


### PR DESCRIPTION
## Summary
Tightens GitHub Actions workflow permissions and pins dependencies by SHA hash.

## Changes
- **scorecard.yml**: Pin `ossf/scorecard-action` and `github/codeql-action/upload-sarif` to SHA hashes
- **landing.yml**: Add top-level `permissions: contents: read` (was missing)
- **codeql.yml**: Move `security-events: write` from top-level to job-level scope
- **Dockerfile**: Pin `node:22-slim` base image to digest

## Code Scanning Alerts Addressed
- **Alert #20** — `TokenPermissionsID` — codeql.yml top-level security-events write
- **Alert #21** — `TokenPermissionsID` — landing.yml no top-level permissions
- **Alert #23, #25, #35** — `PinnedDependenciesID` — scorecard.yml actions not pinned
- **Alert #26** — `PinnedDependenciesID` — Dockerfile image not pinned

Fixes #90