### PR TITLE
fix(security): pin mkdocs-material version in pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.x'
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material==9.7.4
       - run: mkdocs build --strict
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4


### PR DESCRIPTION
## Summary
Pins `mkdocs-material` to version 9.7.4 in the GitHub Pages deployment workflow to address Scorecard alert #27 (unpinned pip dependency).

### Changes
- **pages.yml**: `pip install mkdocs-material` → `pip install mkdocs-material==9.7.4`

### Context
Unpinned pip dependencies allow supply chain attacks where a compromised package version could be installed during CI. Pinning to a specific version ensures reproducible builds.

Closes #99