### PR TITLE
chore(security): add CODEOWNERS and enable branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all files
+* @dorlugasigal


### PR DESCRIPTION
## Summary

Mitigates two HIGH-severity OpenSSF Scorecard alerts from #103:

### Branch Protection (#17)
Enabled on `main` via GitHub API:
- Required status checks: **Lint**, **Coverage**
- Block force pushes and branch deletion
- No mandatory PR reviews (solo developer)

### Code Review (#30)
Added `.github/CODEOWNERS` assigning `@dorlugasigal` as default owner for all files.

### Not addressed (by design)
| Alert | Severity | Reason |
|-------|----------|--------|
| Fuzzing (#34) | MEDIUM | Overkill for project scope |
| SAST (#33) | MEDIUM | Already at 81% coverage |
| CII Badge (#31) | LOW | Process step, not a code fix |
| Maintained (#29) | HIGH | Resolves with time |

Closes #103