### PR TITLE
fix(ui): redirect to session hub when no sessions exist

### DIFF
--- a/public/terminal.html
+++ b/public/terminal.html
@@ -2497,7 +2497,7 @@
 
         if (startId) activateSession(startId);
         else {
-          window.location.href = '/';
+          window.location.replace('/');
           return;
         }
 
@@ -3138,7 +3138,7 @@
           const remaining = [...managed.keys()];
           if (remaining.length > 0) activateSession(remaining[0]);
           else {
-            window.location.href = '/';
+            window.location.replace('/');
             return;
           }
         }
@@ -4228,7 +4228,7 @@
                   const remaining = [...managed.keys()];
                   if (remaining.length > 0) activateSession(remaining[0]);
                   else {
-                    window.location.href = '/';
+                    window.location.replace('/');
                     return;
                   }
                 }

--- a/test/e2e-empty-sessions.test.js
+++ b/test/e2e-empty-sessions.test.js
@@ -1,0 +1,49 @@
+/**
+ * E2E test — redirect to session hub when /terminal has no sessions.
+ *
+ * Run:  npx playwright test test/e2e-empty-sessions.test.js
+ */
+const { test, expect } = require('@playwright/test');
+const { createTermBeamServer } = require('../src/server');
+
+const baseConfig = {
+  port: 0,
+  host: '127.0.0.1',
+  password: null,
+  useTunnel: false,
+  persistedTunnel: false,
+  shell: process.platform === 'win32' ? 'cmd.exe' : '/bin/bash',
+  shellArgs: [],
+  cwd: process.cwd(),
+  defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/bash',
+  version: '0.1.0-test',
+  logLevel: 'error',
+};
+
+let inst;
+
+test.beforeEach(async () => {
+  inst = createTermBeamServer({ config: { ...baseConfig } });
+  await inst.start();
+});
+
+test.afterEach(async () => {
+  if (inst) await inst.shutdown();
+});
+
+test('redirects from /terminal to session hub when no sessions exist', async ({ page }) => {
+  const port = inst.server.address().port;
+  const base = `http://127.0.0.1:${port}`;
+
+  // Delete all sessions so the terminal page has nothing to show
+  const res = await page.request.get(`${base}/api/sessions`);
+  const sessions = await res.json();
+  for (const s of sessions) {
+    await page.request.delete(`${base}/api/sessions/${s.id}`);
+  }
+
+  // Navigate to /terminal — should redirect to /
+  await page.goto(`${base}/terminal`);
+  await expect(page).toHaveURL(`${base}/`, { timeout: 5_000 });
+  await expect(page.locator('.empty-state')).toBeVisible();
+});


### PR DESCRIPTION
When the terminal page (`/terminal`) has no sessions — on initial load, after the last session ends, or when polling detects all sessions are gone — it previously showed a dead-end "No sessions" label with no way forward.

Now it redirects to the session hub (`/`) using `location.replace()` so users land on the proper empty state with a "+ New Session" button, without polluting browser history.

**Changes:**
- Replace three `window.location.href` dead-end states in `terminal.html` with `window.location.replace('/')`
- Add `test/e2e-empty-sessions.test.js` — Playwright E2E test covering the redirect

Closes #121