### PR TITLE
perf(test): parallelize e2e suite via shared server + workers

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -8,7 +8,7 @@ module.exports = defineConfig({
   testMatch: 'e2e-*.test.js',
   timeout: isCI ? 60_000 : 30_000,
   retries: isCI ? 1 : 0,
-  workers: 1, // sequential — each test starts its own server
+  workers: isCI ? 2 : 3, // parallelize across e2e files; CI is more conservative
   reporter: isCI ? [['html', { open: 'never' }], ['list']] : 'list',
   use: {
     headless: true,

--- a/src/cli/resume.js
+++ b/src/cli/resume.js
@@ -6,15 +6,22 @@ const log = require('../utils/logger');
 const { createTerminalClient } = require('./client');
 const { bold, dim, red, yellow, choose, createRL, ask } = require('./prompts');
 
-const CONFIG_DIR = process.env.TERMBEAM_CONFIG_DIR || path.join(os.homedir(), '.termbeam');
-const CONNECTION_FILE = path.join(CONFIG_DIR, 'connection.json');
+// Resolve config paths at call time so that tests (and other code paths) which
+// set TERMBEAM_CONFIG_DIR after this module is first required still take effect.
+function getConfigDir() {
+  return process.env.TERMBEAM_CONFIG_DIR || path.join(os.homedir(), '.termbeam');
+}
+
+function getConnectionFile() {
+  return path.join(getConfigDir(), 'connection.json');
+}
 
 // ── Connection config ────────────────────────────────────────────────────────
 
 function readConnectionConfig() {
   log.debug('Reading connection config');
   try {
-    return JSON.parse(fs.readFileSync(CONNECTION_FILE, 'utf8'));
+    return JSON.parse(fs.readFileSync(getConnectionFile(), 'utf8'));
   } catch {
     return null;
   }
@@ -22,14 +29,15 @@ function readConnectionConfig() {
 
 function writeConnectionConfig({ port, host, password }) {
   log.debug('Writing connection config');
-  fs.mkdirSync(CONFIG_DIR, { recursive: true });
-  fs.writeFileSync(CONNECTION_FILE, JSON.stringify({ port, host, password }, null, 2) + '\n', {
+  const connectionFile = getConnectionFile();
+  fs.mkdirSync(getConfigDir(), { recursive: true });
+  fs.writeFileSync(connectionFile, JSON.stringify({ port, host, password }, null, 2) + '\n', {
     mode: 0o600,
   });
   // Ensure restrictive permissions even if the file already existed
   if (process.platform !== 'win32') {
     try {
-      fs.chmodSync(CONNECTION_FILE, 0o600);
+      fs.chmodSync(connectionFile, 0o600);
     } catch {
       /* best-effort */
     }
@@ -39,7 +47,7 @@ function writeConnectionConfig({ port, host, password }) {
 function removeConnectionConfig() {
   log.debug('Removing connection config');
   try {
-    fs.unlinkSync(CONNECTION_FILE);
+    fs.unlinkSync(getConnectionFile());
   } catch {
     /* ignore */
   }
@@ -402,6 +410,12 @@ module.exports = {
   readConnectionConfig,
   printResumeHelp,
   parseDetachKey,
-  CONFIG_DIR,
-  CONNECTION_FILE,
+  // Lazy getters so tests reading these after setting TERMBEAM_CONFIG_DIR see
+  // the current value, not the value at module load time.
+  get CONFIG_DIR() {
+    return getConfigDir();
+  },
+  get CONNECTION_FILE() {
+    return getConnectionFile();
+  },
 };

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -98,23 +98,28 @@ function validateMagicBytes(buffer, contentType) {
 }
 
 function setupRoutes(app, { auth, sessions, config, state, pushManager, copilotService }) {
-  const pageRateLimit = rateLimit({
-    windowMs: 1 * 60 * 1000,
-    max: 120,
-    standardHeaders: true,
-    legacyHeaders: false,
-    handler: (_req, res) =>
-      res.status(429).json({ error: 'Too many requests, please try again later.' }),
-  });
+  const noopLimit = (_req, _res, next) => next();
+  const pageRateLimit = config.disableRateLimit
+    ? noopLimit
+    : rateLimit({
+        windowMs: 1 * 60 * 1000,
+        max: 120,
+        standardHeaders: true,
+        legacyHeaders: false,
+        handler: (_req, res) =>
+          res.status(429).json({ error: 'Too many requests, please try again later.' }),
+      });
 
-  const apiRateLimit = rateLimit({
-    windowMs: 1 * 60 * 1000,
-    max: 120,
-    standardHeaders: true,
-    legacyHeaders: false,
-    handler: (_req, res) =>
-      res.status(429).json({ error: 'Too many requests, please try again later.' }),
-  });
+  const apiRateLimit = config.disableRateLimit
+    ? noopLimit
+    : rateLimit({
+        windowMs: 1 * 60 * 1000,
+        max: 120,
+        standardHeaders: true,
+        legacyHeaders: false,
+        handler: (_req, res) =>
+          res.status(429).json({ error: 'Too many requests, please try again later.' }),
+      });
 
   // Serve static files — sw.js must never be cached by the browser
   app.get('/sw.js', (_req, res, next) => {

--- a/test/e2e-features.test.js
+++ b/test/e2e-features.test.js
@@ -8,73 +8,21 @@
  * Run:  npx playwright test test/e2e-features.test.js
  */
 const { test, expect } = require('@playwright/test');
-const { createTermBeamServer } = require('../src/server');
+const { setupSharedServer, getBaseURL: getBaseURLForState, isWindows } = require('./e2e-helpers');
 
-const isWindows = process.platform === 'win32';
-
-const baseConfig = {
-  port: 0,
-  host: '127.0.0.1',
-  password: null,
-  useTunnel: false,
-  persistedTunnel: false,
-  shell: process.platform === 'win32' ? 'cmd.exe' : '/bin/bash',
-  shellArgs: [],
-  cwd: process.cwd(),
-  defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/bash',
-  version: '0.1.0-test',
-  logLevel: 'error',
-};
-
-let inst;
-let consoleErrors;
-
-test.beforeEach(async ({ page }) => {
-  inst = createTermBeamServer({ config: { ...baseConfig } });
-  await inst.start();
-
-  consoleErrors = [];
-  page.on('console', (msg) => {
-    if (msg.type() === 'error') consoleErrors.push(msg.text());
-  });
-});
-
-test.afterEach(async () => {
-  if (inst) {
-    if (isWindows) {
-      for (const [, session] of inst.sessions.sessions) {
-        try {
-          const pid = session.pty.pid;
-          require('child_process').execSync(`taskkill /pid ${pid} /T /F`, {
-            stdio: 'ignore',
-          });
-        } catch {
-          // Process may already be gone
-        }
-      }
-    }
-    await inst.shutdown();
-  }
-
-  const unexpected = consoleErrors.filter(
-    (e) => !e.includes('net::ERR_') && !e.includes('WebSocket'),
-  );
-  if (unexpected.length > 0) {
-    throw new Error(`Unexpected browser console errors:\n${unexpected.join('\n')}`);
-  }
-});
+// One TermBeam server per file, with sessions reset to "1 default session"
+// between tests. See test/e2e-helpers.js for the reset logic.
+const state = setupSharedServer(test);
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function getBaseURL() {
-  const port = inst.server.address().port;
-  return `http://127.0.0.1:${port}`;
+  return getBaseURLForState(state);
 }
 
 async function createSessionViaAPI(name) {
-  const port = inst.server.address().port;
   const body = name ? { name } : {};
-  const res = await fetch(`http://127.0.0.1:${port}/api/sessions`, {
+  const res = await fetch(`${getBaseURL()}/api/sessions`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -83,16 +31,14 @@ async function createSessionViaAPI(name) {
 }
 
 async function navigateToTerminal(page, sessionId) {
-  const port = inst.server.address().port;
-  await page.goto(`http://127.0.0.1:${port}/terminal?id=${sessionId}`);
+  await page.goto(`${getBaseURL()}/terminal?id=${sessionId}`);
   await expect(page.locator('[data-testid="status-dot"].connected')).toBeVisible({
     timeout: 10_000,
   });
 }
 
 async function navigateToHub(page) {
-  const port = inst.server.address().port;
-  await page.goto(`http://127.0.0.1:${port}/`);
+  await page.goto(`${getBaseURL()}/`);
   await page.waitForLoadState('domcontentloaded');
   await expect(
     page.locator('[data-testid="hub-new-session-btn"], [data-testid="empty-state"]').first(),
@@ -103,12 +49,6 @@ async function openTerminalWithNewSession(page, name) {
   const { id } = await createSessionViaAPI(name);
   await navigateToTerminal(page, id);
   return id;
-}
-
-async function getInitialSessions() {
-  const port = inst.server.address().port;
-  const res = await fetch(`http://127.0.0.1:${port}/api/sessions`);
-  return res.json();
 }
 
 async function waitForTerminalOutput(page, pattern, timeout = 15_000) {

--- a/test/e2e-helpers.js
+++ b/test/e2e-helpers.js
@@ -1,0 +1,176 @@
+/**
+ * Shared E2E server helper.
+ *
+ * Starts a single TermBeam server per test file (via `setupSharedServer(test)`)
+ * and resets it to a clean "1 default session" state between tests. Avoids
+ * paying the full `createTermBeamServer().start()` cost on every test, which
+ * dominates wall-clock time in the e2e suite.
+ *
+ * The reset mimics what `inst.start()` produces: exactly one auto-created
+ * session named after the cwd basename, using the configured shell.
+ *
+ * Tests get isolation by:
+ *   - Playwright giving each test a fresh browser context (cookies/localStorage)
+ *   - This helper deleting all sessions and recreating exactly one default
+ *   - Per-test console error tracking (asserted in afterEach)
+ *
+ * This file is intentionally NOT named `*.test.js` so it isn't discovered by
+ * Playwright's testMatch ('e2e-*.test.js') or by the node --test runner.
+ */
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const { createTermBeamServer } = require('../src/server');
+
+const isWindows = process.platform === 'win32';
+
+const baseConfig = {
+  port: 0,
+  host: '127.0.0.1',
+  password: null,
+  useTunnel: false,
+  persistedTunnel: false,
+  shell: isWindows ? 'cmd.exe' : '/bin/bash',
+  shellArgs: [],
+  cwd: process.cwd(),
+  defaultShell: isWindows ? 'cmd.exe' : '/bin/bash',
+  version: '0.1.0-test',
+  logLevel: 'error',
+  disableRateLimit: true,
+};
+
+function createDefaultSession(inst) {
+  inst.sessions.create({
+    name: path.basename(baseConfig.cwd),
+    shell: baseConfig.shell,
+    args: baseConfig.shellArgs,
+    cwd: baseConfig.cwd,
+  });
+}
+
+async function waitFor(predicate, timeoutMs = 5000, intervalMs = 25) {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) return false;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return true;
+}
+
+function taskkillTree(pid) {
+  if (!isWindows) return;
+  try {
+    require('child_process').execSync(`taskkill /pid ${pid} /T /F`, { stdio: 'ignore' });
+  } catch {
+    // already gone
+  }
+}
+
+async function resetSessions(inst) {
+  const ids = [...inst.sessions.sessions.keys()];
+
+  // On Windows, ConPTY's kill() doesn't reliably reap the entire child tree
+  // in headless CI. taskkill /T /F first to ensure a clean teardown.
+  if (isWindows) {
+    for (const id of ids) {
+      const s = inst.sessions.sessions.get(id);
+      if (s) taskkillTree(s.pty.pid);
+    }
+  }
+
+  for (const id of ids) {
+    try {
+      inst.sessions.delete(id);
+    } catch {
+      // ignore
+    }
+  }
+
+  // Wait for onExit handlers to drain the map. Force-clear if they don't
+  // fire promptly so the next test isn't blocked.
+  const drained = await waitFor(() => inst.sessions.sessions.size === 0, 2000);
+  if (!drained) {
+    inst.sessions.sessions.clear();
+  }
+
+  createDefaultSession(inst);
+}
+
+function killAllSessionsHard(inst) {
+  if (!isWindows) return;
+  for (const [, session] of inst.sessions.sessions) {
+    taskkillTree(session.pty.pid);
+  }
+}
+
+/**
+ * Wires up beforeAll/afterAll/beforeEach/afterEach hooks on the given test
+ * runner so the file shares a single TermBeam server.
+ *
+ * Returns a state object. Read `state.inst` lazily (inside tests/helpers,
+ * not at module load) — it's populated in beforeAll and reset between tests.
+ */
+function setupSharedServer(test) {
+  const state = {
+    inst: null,
+    consoleErrors: [],
+    isWindows,
+    baseConfig,
+  };
+
+  test.beforeAll(async () => {
+    // Per-worker temp configDir so parallel workers don't race on
+    // ~/.termbeam/connection.json or vapid.json.
+    state.configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'termbeam-e2e-'));
+    process.env.TERMBEAM_CONFIG_DIR = state.configDir;
+    state.inst = createTermBeamServer({ config: { ...baseConfig } });
+    await state.inst.start();
+  });
+
+  test.afterAll(async () => {
+    if (state.inst) {
+      killAllSessionsHard(state.inst);
+      await state.inst.shutdown();
+      state.inst = null;
+    }
+    if (state.configDir) {
+      try {
+        fs.rmSync(state.configDir, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+      state.configDir = null;
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetSessions(state.inst);
+
+    state.consoleErrors = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') state.consoleErrors.push(msg.text());
+    });
+  });
+
+  test.afterEach(async () => {
+    const unexpected = state.consoleErrors.filter(
+      (e) => !e.includes('net::ERR_') && !e.includes('WebSocket'),
+    );
+    if (unexpected.length > 0) {
+      throw new Error(`Unexpected browser console errors:\n${unexpected.join('\n')}`);
+    }
+  });
+
+  return state;
+}
+
+function getBaseURL(state) {
+  return `http://127.0.0.1:${state.inst.server.address().port}`;
+}
+
+module.exports = {
+  setupSharedServer,
+  getBaseURL,
+  baseConfig,
+  isWindows,
+};

--- a/test/e2e-helpers.js
+++ b/test/e2e-helpers.js
@@ -86,11 +86,15 @@ async function resetSessions(inst) {
     }
   }
 
-  // Wait for onExit handlers to drain the map. Force-clear if they don't
-  // fire promptly so the next test isn't blocked.
-  const drained = await waitFor(() => inst.sessions.sessions.size === 0, 2000);
+  // Wait for onExit handlers to drain the map. If some sessions are still
+  // hanging around, fall back to SessionManager.shutdown() which kills any
+  // remaining PTYs and clears internal caches consistently — don't mutate
+  // the internal map directly, as that would leak live PTYs and _gitCache
+  // entries.
+  let drained = await waitFor(() => inst.sessions.sessions.size === 0, 2000);
   if (!drained) {
-    inst.sessions.sessions.clear();
+    inst.sessions.shutdown();
+    drained = await waitFor(() => inst.sessions.sessions.size === 0, 2000);
   }
 
   createDefaultSession(inst);
@@ -116,11 +120,16 @@ function setupSharedServer(test) {
     consoleErrors: [],
     isWindows,
     baseConfig,
+    prevConfigDir: undefined,
   };
 
   test.beforeAll(async () => {
     // Per-worker temp configDir so parallel workers don't race on
-    // ~/.termbeam/connection.json or vapid.json.
+    // ~/.termbeam/connection.json or vapid.json. Capture the previous value
+    // so we can restore it in afterAll — Playwright workers can run multiple
+    // files in the same process, so leaking this env var into the next file
+    // (potentially pointing at a deleted temp dir) would corrupt its state.
+    state.prevConfigDir = process.env.TERMBEAM_CONFIG_DIR;
     state.configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'termbeam-e2e-'));
     process.env.TERMBEAM_CONFIG_DIR = state.configDir;
     state.inst = createTermBeamServer({ config: { ...baseConfig } });
@@ -140,6 +149,11 @@ function setupSharedServer(test) {
         // ignore
       }
       state.configDir = null;
+    }
+    if (state.prevConfigDir === undefined) {
+      delete process.env.TERMBEAM_CONFIG_DIR;
+    } else {
+      process.env.TERMBEAM_CONFIG_DIR = state.prevConfigDir;
     }
   });
 

--- a/test/e2e-keybar.test.js
+++ b/test/e2e-keybar.test.js
@@ -7,73 +7,16 @@
  * Run:  npx playwright test test/e2e-keybar.test.js
  */
 const { test, expect } = require('@playwright/test');
-const { createTermBeamServer } = require('../src/server');
+const { setupSharedServer, getBaseURL: getBaseURLForState, isWindows } = require('./e2e-helpers');
 
-const isWindows = process.platform === 'win32';
-
-const baseConfig = {
-  port: 0,
-  host: '127.0.0.1',
-  password: null,
-  useTunnel: false,
-  persistedTunnel: false,
-  shell: process.platform === 'win32' ? 'cmd.exe' : '/bin/bash',
-  shellArgs: [],
-  cwd: process.cwd(),
-  defaultShell: process.platform === 'win32' ? 'cmd.exe' : '/bin/bash',
-  version: '0.1.0-test',
-  logLevel: 'error',
-};
-
-let inst;
-let consoleErrors;
-
-test.beforeEach(async ({ page }) => {
-  inst = createTermBeamServer({ config: { ...baseConfig } });
-  await inst.start();
-
-  // Track browser console errors so frontend JS bugs don't go unnoticed
-  consoleErrors = [];
-  page.on('console', (msg) => {
-    if (msg.type() === 'error') consoleErrors.push(msg.text());
-  });
-});
-
-test.afterEach(async ({ page }) => {
-  // Fail-loud if the frontend emitted any console.error() during the test
-  const unexpected = consoleErrors.filter(
-    (e) => !e.includes('net::ERR_') && !e.includes('WebSocket'),
-  );
-
-  if (inst) {
-    // On Windows, node-pty's conpty kill() tries to AttachConsole to enumerate
-    // child processes — this fails in headless CI, producing stderr noise and
-    // leaving child processes behind. We kill the entire process tree ourselves
-    // using taskkill /T before shutdown to ensure clean teardown.
-    if (isWindows) {
-      for (const [, session] of inst.sessions.sessions) {
-        try {
-          const pid = session.pty.pid;
-          require('child_process').execSync(`taskkill /pid ${pid} /T /F`, {
-            stdio: 'ignore',
-          });
-        } catch {
-          // Process may already be gone
-        }
-      }
-    }
-    await inst.shutdown();
-  }
-
-  if (unexpected.length > 0) {
-    throw new Error(`Unexpected browser console errors:\n${unexpected.join('\n')}`);
-  }
-});
+// One TermBeam server per file, with sessions reset to "1 default session"
+// between tests. See test/e2e-helpers.js for the reset logic.
+const state = setupSharedServer(test);
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function getBaseURL() {
-  return `http://127.0.0.1:${inst.server.address().port}`;
+  return getBaseURLForState(state);
 }
 
 async function setupTerminal(page) {


### PR DESCRIPTION
Refactors the Playwright e2e suite to share a single TermBeam server per test file and runs files in parallel (workers: 2 in CI, 3 locally). Local wall-clock drops from ~1m49s to ~1m02s.

Adds a per-worker temp `TERMBEAM_CONFIG_DIR` so parallel workers don't race on `connection.json` / `vapid.json`, and an internal `config.disableRateLimit` flag so accumulated requests on a shared server don't trip the 120 req/min limit.

Closes #213