### PR TITLE
refactor(site): clean up landing page design and optimize CI

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -20,8 +20,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-github-pages:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - name: github-pages
+            deploy_target: ''
+            site_url: ''
+          - name: cloudflare
+            deploy_target: cloudflare
+            site_url: https://termbeam.pages.dev
     defaults:
       run:
         working-directory: packages/site
@@ -34,16 +43,26 @@ jobs:
           cache-dependency-path: packages/site/package-lock.json
       - name: Install dependencies
         run: npm ci
-      - name: Build with Astro (GitHub Pages target)
+      - name: Build with Astro
+        env:
+          DEPLOY_TARGET: ${{ matrix.target.deploy_target }}
+          SITE_URL: ${{ matrix.target.site_url }}
         run: npm run build
       - name: Upload Pages artifact
+        if: matrix.target.name == 'github-pages'
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
+          path: packages/site/dist
+      - name: Upload Cloudflare artifact
+        if: matrix.target.name == 'cloudflare'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cloudflare-dist
           path: packages/site/dist
 
   deploy-github-pages:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    needs: build-github-pages
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -59,6 +78,7 @@ jobs:
 
   deploy-cloudflare-pages:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -66,23 +86,15 @@ jobs:
     environment:
       name: cloudflare-pages
       url: https://termbeam.pages.dev
-    defaults:
-      run:
-        working-directory: packages/site
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: packages/site/package-lock.json
-      - name: Install dependencies
-        run: npm ci
-      - name: Build with Astro (Cloudflare target)
-        env:
-          DEPLOY_TARGET: cloudflare
-          SITE_URL: https://termbeam.pages.dev
-        run: npm run build
+          sparse-checkout: packages/site
+      - name: Download Cloudflare build
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: cloudflare-dist
+          path: packages/site/dist
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
         with:

--- a/packages/site/src/components/FeatureSection.astro
+++ b/packages/site/src/components/FeatureSection.astro
@@ -9,6 +9,7 @@ export interface Props {
   device: 'browser' | 'phone';
   layout: 'center' | 'split' | 'split-reverse';
   xl?: boolean;
+  lazy?: boolean;
 }
 
 const {
@@ -21,6 +22,7 @@ const {
   device,
   layout,
   xl = true,
+  lazy = false,
 } = Astro.props;
 
 const base = import.meta.env.BASE_URL.replace(/\/+$/, '');
@@ -71,7 +73,8 @@ const deviceXL =
                   playsinline
                   width="2560"
                   height="1440"
-                  preload="metadata"
+                  preload={lazy ? 'none' : 'metadata'}
+                  loading={lazy ? 'lazy' : undefined}
                   aria-label={`Demo of ${title}`}
                 />
                 <button class="video-replay" type="button" hidden aria-label={`Replay ${title} demo`}>
@@ -93,7 +96,8 @@ const deviceXL =
                   playsinline
                   width="1170"
                   height="2532"
-                  preload="metadata"
+                  preload={lazy ? 'none' : 'metadata'}
+                  loading={lazy ? 'lazy' : undefined}
                   aria-label={`Demo of ${title}`}
                 />
                 <button class="video-replay" type="button" hidden aria-label={`Replay ${title} demo`}>

--- a/packages/site/src/layouts/MarketingLayout.astro
+++ b/packages/site/src/layouts/MarketingLayout.astro
@@ -78,12 +78,7 @@ const siteUrl = new URL(`${base}/`.replace(/\/+/g, '/'), Astro.site).toString();
   <body>
     <a href="#main-content" class="skip-nav">Skip to content</a>
 
-    <div class="noise-overlay" aria-hidden="true"></div>
-    <div class="gradient-mesh" aria-hidden="true">
-      <div class="mesh-blob mesh-blob-1"></div>
-      <div class="mesh-blob mesh-blob-2"></div>
-      <div class="mesh-blob mesh-blob-3"></div>
-    </div>
+    <div class="hero-glow" aria-hidden="true"></div>
 
     <slot />
 

--- a/packages/site/src/pages/index.astro
+++ b/packages/site/src/pages/index.astro
@@ -29,6 +29,7 @@ const features = [
     posterSrc: 'showcase/agents-desktop.png',
     device: 'browser' as const,
     layout: 'split' as const,
+    lazy: true,
   },
   {
     num: '03',
@@ -40,6 +41,7 @@ const features = [
     posterSrc: 'showcase/terminal-mobile.png',
     device: 'phone' as const,
     layout: 'split-reverse' as const,
+    lazy: true,
   },
   {
     num: '04',
@@ -51,6 +53,7 @@ const features = [
     posterSrc: 'showcase/voice-mobile.png',
     device: 'phone' as const,
     layout: 'split' as const,
+    lazy: true,
   },
   {
     num: '05',
@@ -62,6 +65,7 @@ const features = [
     posterSrc: 'showcase/sessions-desktop.png',
     device: 'browser' as const,
     layout: 'split-reverse' as const,
+    lazy: true,
   },
   {
     num: '06',
@@ -73,6 +77,7 @@ const features = [
     posterSrc: 'showcase/theme-mobile.png',
     device: 'phone' as const,
     layout: 'split' as const,
+    lazy: true,
   },
 ];
 ---
@@ -503,6 +508,8 @@ const features = [
       <div class="footer-brand"><span class="nav-logo-beam">▸</span> TermBeam</div>
       <div class="footer-links">
         <a href={docsLink}>Documentation</a>
+        <a href={`${base}/use-cases/`}>Use Cases</a>
+        <a href={`${base}/ai-agents/`}>AI Agents</a>
         <a href="https://github.com/dorlugasigal/TermBeam" target="_blank" rel="noopener noreferrer"
           >GitHub</a
         >

--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -78,7 +78,7 @@
 
   --color-fg: #0a0a0a;
   --color-fg-muted: #475569;
-  --color-fg-dim: #64748b;
+  --color-fg-dim: #52525b;
 
   --color-accent: #1d4ed8;
   --color-accent-soft: rgba(29, 78, 216, 0.12);

--- a/packages/site/src/styles/landing.css
+++ b/packages/site/src/styles/landing.css
@@ -73,116 +73,13 @@ code {
   border-radius: 6px;
 }
 
-/* ─── Noise Overlay ────────────────────────────────────── */
-.noise-overlay {
-  position: fixed;
-  inset: -10%;
-  z-index: 100;
-  pointer-events: none;
-  opacity: 0.03;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-  background-repeat: repeat;
-  background-size: 256px 256px;
-  animation: grain 1.5s steps(2) infinite;
-}
-
-@keyframes grain {
-  0%,
-  100% {
-    transform: translate(0, 0);
-  }
-  25% {
-    transform: translate(-5%, 5%);
-  }
-  50% {
-    transform: translate(5%, -5%);
-  }
-  75% {
-    transform: translate(-2%, 2%);
-  }
-}
-
-/* ─── Gradient Mesh Background ─────────────────────────── */
-.gradient-mesh {
+/* ─── Hero Glow — single, anchored accent radial ──────── */
+.hero-glow {
   position: fixed;
   inset: 0;
   z-index: 0;
-  overflow: hidden;
   pointer-events: none;
-  contain: layout style paint;
-}
-
-.mesh-blob {
-  position: absolute;
-  border-radius: 50%;
-  filter: blur(120px);
-  opacity: 0.2;
-}
-
-.mesh-blob-1 {
-  width: 700px;
-  height: 700px;
-  background: radial-gradient(circle, #3b82f6 0%, transparent 70%);
-  top: -20%;
-  left: -10%;
-  animation: drift1 20s ease-in-out infinite;
-}
-
-.mesh-blob-2 {
-  width: 600px;
-  height: 600px;
-  background: radial-gradient(circle, #8b5cf6 0%, transparent 70%);
-  top: 10%;
-  right: -15%;
-  animation: drift2 25s ease-in-out infinite;
-}
-
-.mesh-blob-3 {
-  width: 500px;
-  height: 500px;
-  background: radial-gradient(circle, #06b6d4 0%, transparent 70%);
-  bottom: -10%;
-  left: 30%;
-  animation: drift3 22s ease-in-out infinite;
-}
-
-@keyframes drift1 {
-  0%,
-  100% {
-    transform: translate(0, 0) scale(1);
-  }
-  33% {
-    transform: translate(80px, 60px) scale(1.1);
-  }
-  66% {
-    transform: translate(-40px, 100px) scale(0.95);
-  }
-}
-
-@keyframes drift2 {
-  0%,
-  100% {
-    transform: translate(0, 0) scale(1);
-  }
-  33% {
-    transform: translate(-100px, 40px) scale(0.9);
-  }
-  66% {
-    transform: translate(60px, -60px) scale(1.05);
-  }
-}
-
-@keyframes drift3 {
-  0%,
-  100% {
-    transform: translate(0, 0) scale(1);
-  }
-  33% {
-    transform: translate(60px, -80px) scale(1.1);
-  }
-  66% {
-    transform: translate(-80px, 30px) scale(0.95);
-  }
+  background: radial-gradient(ellipse 70% 50% at 50% 0%, var(--mesh-1) 0%, transparent 70%);
 }
 
 /* ─── Typography ───────────────────────────────────────── */
@@ -201,11 +98,7 @@ h2 {
 }
 
 .text-gradient {
-  background: linear-gradient(135deg, #60a5fa 0%, #c084fc 50%, #22d3ee 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  filter: brightness(1.1);
+  color: var(--accent-light);
 }
 
 .section-label {
@@ -923,23 +816,17 @@ section[id] {
 }
 
 .feature-tags span {
-  font-size: 0.75rem;
+  font-size: 0.8rem;
   font-weight: 500;
-  color: var(--text-secondary);
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid var(--border);
-  border-radius: 100px;
-  padding: 5px 14px;
-  transition:
-    background 0.2s,
-    border-color 0.2s,
-    color 0.2s;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
 }
 
-.feature-tags span:hover {
-  background: rgba(255, 255, 255, 0.07);
-  border-color: rgba(255, 255, 255, 0.12);
-  color: var(--text);
+.feature-tags span + span::before {
+  content: '·';
+  margin-right: 8px;
+  color: var(--text-muted);
+  opacity: 0.5;
 }
 
 /* ─── Feature Visual ──────────────────────────────────── */
@@ -1087,7 +974,6 @@ section[id] {
     90deg,
     transparent,
     rgba(59, 130, 246, 0.3),
-    rgba(139, 92, 246, 0.3),
     transparent
   );
 }
@@ -1128,7 +1014,7 @@ section[id] {
   position: absolute;
   inset: -2px;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent), #8b5cf6);
+  background: var(--accent);
   z-index: -1;
 }
 
@@ -1150,22 +1036,8 @@ section[id] {
 .connector-gradient {
   width: 100%;
   height: 100%;
-  background: linear-gradient(90deg, var(--accent), #8b5cf6, var(--accent));
-  background-size: 200% 100%;
-  animation: gradient-sweep 3s ease-in-out infinite;
-  opacity: 0.5;
-}
-
-@keyframes gradient-sweep {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
+  background: var(--accent);
+  opacity: 0.3;
 }
 
 .step h3 {
@@ -1201,7 +1073,6 @@ section[id] {
     90deg,
     transparent,
     rgba(59, 130, 246, 0.3),
-    rgba(139, 92, 246, 0.3),
     transparent
   );
 }


### PR DESCRIPTION
Cleans up the landing page CSS and optimizes the site deployment workflow.

Landing page: removed noise overlay and gradient mesh (AI slop), simplified text gradients to solid colors, replaced pill tags with plain text separators, bumped light-mode contrast for WCAG AA, added lazy loading to feature videos, and added missing footer links.

CI: replaced the duplicate build jobs in site.yml with a single matrix-based build job. Both GitHub Pages and Cloudflare builds now share checkout/setup/install and run in parallel. Cloudflare deploy downloads the pre-built artifact instead of rebuilding.

Closes #219