### PR TITLE
fix(version): make /api/version recompute per request again

### DIFF
--- a/packages/site/src/content/docs/api.md
+++ b/packages/site/src/content/docs/api.md
@@ -528,7 +528,7 @@ Returned when the server was started with `--no-password`.
 
 #### `GET /api/version`
 
-Get the server version. The value is captured once at process startup and reflects the running code (not the latest git state on disk). Restart the service to pick up a new version.
+Get the server version. Recomputed per request so dev source checkouts surface new commits and dirty state without a restart. Production installs short-circuit to the cached `package.json` value, so the cost is negligible.
 
 **Response:**
 

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -163,12 +163,14 @@ function setupRoutes(
     }
   });
 
-  // Version API — uses the version captured at server startup so dev/prod
-  // builds stay stable for the lifetime of the process. Restart the service
-  // to pick up a new git tag or dirty-state change.
+  // Version API — recomputes per request so dev source checkouts surface new
+  // commits/dirty state without a restart. In production (npm install) the
+  // npm_package_version short-circuit in getVersion() makes this a cheap
+  // package.json read; only source checkouts incur the git describe cost.
   app.get('/api/version', (_req, res) => {
     log.debug('Version requested');
-    res.json({ version: config.version });
+    const { getVersion } = require('../utils/version');
+    res.json({ version: getVersion() });
   });
 
   // Changelog — served from repo CHANGELOG.md (bundled with the npm package).


### PR DESCRIPTION
Reverts just the route caching from 6fde7640 — `/api/version` now re-runs `getVersion()` on each request, so a dev source checkout's badge updates after a commit or pull without a service restart. Production npm installs are unaffected: the `npm_package_version` short-circuit in `getVersion()` returns the cached package.json value, so no extra git work happens there. The dirty-untracked detection added in the same original commit is preserved.

Closes #226.