### PR TITLE
feat(ui): polish SidePanel and add Sessions hub fold-in cascade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1774,9 +1774,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2076,12 +2076,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
-      "integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2542,9 +2542,9 @@
       "optional": true
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/src/frontend/src/components/SessionsHub/SessionCard.module.css
+++ b/src/frontend/src/components/SessionsHub/SessionCard.module.css
@@ -12,6 +12,40 @@
   animation-delay: calc(var(--stagger-i, 0) * 45ms);
 }
 
+/*
+ * "Fold-in" arrival — cards rotate down on the X-axis from above, like
+ * folding into place from a horizontal plane. No overshoot at the end —
+ * the previous bounce-back caused a visible micro-jitter on the final
+ * frames. The perspective lives on the parent .sessionsList only;
+ * specifying it again inside the keyframe transforms caused inconsistent
+ * compositing.
+ *
+ * SessionsHub flips data-arriving for ~2s after the initial fetch resolves
+ * (8 cards * 220ms stagger + 0.38s duration ≈ 2.1s).
+ */
+.wrapper[data-arriving='true'] {
+  animation: fold-in 0.38s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: calc(var(--stagger-i, 0) * 220ms);
+  transform-origin: top center;
+}
+
+@keyframes fold-in {
+  from {
+    opacity: 0;
+    transform: rotateX(-72deg);
+  }
+  to {
+    opacity: 1;
+    transform: rotateX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wrapper[data-arriving='true'] {
+    animation: none;
+  }
+}
+
 .deleteBackground {
   position: absolute;
   top: 0;

--- a/src/frontend/src/components/SessionsHub/SessionCard.tsx
+++ b/src/frontend/src/components/SessionsHub/SessionCard.tsx
@@ -17,6 +17,12 @@ interface SessionCardProps {
    */
   index?: number;
   /**
+   * When true, the card is part of the post-load "magical arrival" — uses
+   * a richer, slightly slower stagger so the freshly-fetched list cascades
+   * in with more presence than ordinary mounts.
+   */
+  arriving?: boolean;
+  /**
    * When true, the card is playing the disintegrate (Thanos-snap)
    * animation prior to being removed. Disables interaction and applies
    * the dust effect via a CSS modifier class.
@@ -104,6 +110,7 @@ export default function SessionCard({
   revealedId,
   onRevealChange,
   index = 0,
+  arriving = false,
   dissolving = false,
 }: SessionCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
@@ -225,6 +232,7 @@ export default function SessionCard({
       className={`${styles.wrapper} ${dissolving ? dissolveStyles.dissolving : ''}`}
       style={{ ['--stagger-i' as string]: Math.min(index, 8) }}
       data-session-id={session.id}
+      data-arriving={arriving || undefined}
       aria-hidden={dissolving || undefined}
     >
       <button

--- a/src/frontend/src/components/SessionsHub/SessionsHub.module.css
+++ b/src/frontend/src/components/SessionsHub/SessionsHub.module.css
@@ -99,6 +99,17 @@
   gap: 12px;
 }
 
+/*
+ * During the post-load "fold-in" cascade, give the list a perspective so
+ * each SessionCard's rotateX renders as real 3D depth instead of a flat
+ * vertical squish. The attribute is removed once the cascade finishes, so
+ * we don't pay any rendering cost in steady state.
+ */
+.sessionsList[data-arriving='true'] {
+  perspective: 1100px;
+  perspective-origin: 50% -10%;
+}
+
 .emptyState {
   display: flex;
   flex-direction: column;

--- a/src/frontend/src/components/SessionsHub/SessionsHub.tsx
+++ b/src/frontend/src/components/SessionsHub/SessionsHub.tsx
@@ -84,12 +84,14 @@ const RefreshIcon = () => (
 export default function SessionsHub() {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
+  const [arriving, setArriving] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [version, setVersion] = useState('');
   const [revealedId, setRevealedId] = useState<string | null>(null);
   const [filter, setFilter] = useState<SessionFilterState>(() => loadFilterFromStorage());
   const [workspaceLauncherOpen, setWorkspaceLauncherOpen] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
+  const prevLoadingRef = useRef(true);
   const {
     openNewSessionModal,
     openResumeBrowser,
@@ -127,6 +129,19 @@ export default function SessionsHub() {
     const timer = setInterval(loadSessions, POLL_INTERVAL);
     return () => clearInterval(timer);
   }, [loadSessions]);
+
+  // SessionsHub flips arriving=true for ~2s once the initial fetch resolves
+  // so the sequential fold-in cascade has room to play (8 cards * 220ms
+  // stagger + 0.38s duration ≈ 2.1s).
+  useEffect(() => {
+    if (prevLoadingRef.current && !loading) {
+      setArriving(true);
+      const t = setTimeout(() => setArriving(false), 2200);
+      prevLoadingRef.current = loading;
+      return () => clearTimeout(t);
+    }
+    prevLoadingRef.current = loading;
+  }, [loading]);
 
   useEffect(() => {
     fetchVersion().then((v) => {
@@ -285,12 +300,7 @@ export default function SessionsHub() {
       <ThemePicker open={themePickerOpen} onClose={closeThemePicker} hideTrigger />
 
       <main className={styles.content}>
-        {loading ? (
-          <div className={styles.emptyState}>
-            <span className={styles.emptyIcon}>⏳</span>
-            <span className={styles.emptyText}>Loading sessions…</span>
-          </div>
-        ) : sessions.length === 0 ? (
+        {loading ? null : sessions.length === 0 ? (
           <div className={styles.emptyState} data-testid="empty-state">
             <Wordmark size="md" />
             <span className={styles.emptyText}>No active sessions</span>
@@ -397,6 +407,7 @@ export default function SessionsHub() {
                 className={styles.sessionsList}
                 data-testid="sessions-list"
                 data-filter-active={filterActive || undefined}
+                data-arriving={arriving || undefined}
               >
                 {visibleSessions.map((session, i) => (
                   <SessionCard
@@ -407,6 +418,7 @@ export default function SessionsHub() {
                     revealedId={revealedId}
                     onRevealChange={setRevealedId}
                     index={i}
+                    arriving={arriving}
                     dissolving={dissolvingIds.has(session.id)}
                   />
                 ))}

--- a/src/frontend/src/components/SessionsHub/SessionsHub.tsx
+++ b/src/frontend/src/components/SessionsHub/SessionsHub.tsx
@@ -299,7 +299,7 @@ export default function SessionsHub() {
 
       <ThemePicker open={themePickerOpen} onClose={closeThemePicker} hideTrigger />
 
-      <main className={styles.content}>
+      <main className={styles.content} aria-busy={loading || undefined}>
         {loading ? null : sessions.length === 0 ? (
           <div className={styles.emptyState} data-testid="empty-state">
             <Wordmark size="md" />

--- a/src/frontend/src/components/SidePanel/SidePanel.module.css
+++ b/src/frontend/src/components/SidePanel/SidePanel.module.css
@@ -139,9 +139,9 @@
 
 /*
  * Active session: just a 3px left-edge accent stripe. The card border stays
- * neutral (--border) — no accent tint anywhere else. Earlier iterations
- * tinted the border or background and the result still read as a colored
- * box. The stripe alone is the only chromatic cue.
+ * neutral (--border) — no accent tint anywhere else, even on hover. Earlier
+ * iterations tinted the border or background and the result still read as
+ * a colored box. The stripe alone is the only chromatic cue.
  */
 .cardActive::before {
   content: '';
@@ -153,6 +153,15 @@
   background: var(--accent);
   border-radius: 10px 0 0 10px;
   pointer-events: none;
+}
+
+/*
+ * The generic .card:hover above tints every card's border with an accent
+ * color-mix. Override it for the active card so its border stays neutral
+ * on hover too — the left-edge stripe is the only visual cue we want.
+ */
+.cardActive:hover {
+  border-color: var(--border);
 }
 
 /* Card header row */

--- a/src/frontend/src/components/SidePanel/SidePanel.module.css
+++ b/src/frontend/src/components/SidePanel/SidePanel.module.css
@@ -17,7 +17,7 @@
   bottom: 0;
   z-index: 201;
   width: min(85vw, 380px);
-  background: var(--surface);
+  background: var(--bg);
   border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
@@ -119,7 +119,8 @@
 /* ── Session card ── */
 
 .card {
-  background: var(--bg);
+  position: relative;
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 10px;
   cursor: pointer;
@@ -133,12 +134,25 @@
 }
 
 .card:hover {
-  border-color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
 }
 
-.cardActive {
-  border-color: var(--accent);
-  border-width: 2px;
+/*
+ * Active session: just a 3px left-edge accent stripe. The card border stays
+ * neutral (--border) — no accent tint anywhere else. Earlier iterations
+ * tinted the border or background and the result still read as a colored
+ * box. The stripe alone is the only chromatic cue.
+ */
+.cardActive::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  background: var(--accent);
+  border-radius: 10px 0 0 10px;
+  pointer-events: none;
 }
 
 /* Card header row */
@@ -155,6 +169,15 @@
   height: 10px;
   border-radius: 50%;
   flex-shrink: 0;
+  /*
+   * Combined session-color + connection-status indicator. The dot itself
+   * carries the session color (set inline). A 2px gap (matching surface)
+   * then a 2px halo ring (status color) are layered via box-shadow so the
+   * single visual conveys both pieces of state without duplicate dots.
+   * The actual ring color is set inline alongside the background.
+   */
+  margin-right: 4px;
+  transition: box-shadow 0.2s ease;
 }
 
 .cardName {
@@ -165,13 +188,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.cardStatus {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  flex-shrink: 0;
 }
 
 .cardClose {
@@ -226,7 +242,7 @@
   display: inline-flex;
   align-items: center;
   gap: 3px;
-  background: var(--surface);
+  background: var(--bg);
   padding: 1px 6px;
   border-radius: 3px;
 }
@@ -244,7 +260,7 @@
 .cardPreview {
   margin: 0 8px 8px;
   padding: 6px 8px;
-  background: var(--surface);
+  background: var(--bg);
   border-radius: 6px;
   font-family: 'NerdFont', 'JetBrains Mono', monospace;
   font-size: 9px;
@@ -274,16 +290,22 @@
 
 .footerRow {
   display: flex;
-  gap: 6px;
+  gap: 8px;
 }
 
-.footerBtn {
+/*
+ * Footer hierarchy: "+ New Session" is the primary action (filled accent),
+ * "↺ Resume" is secondary (solid border, neutral text). Replaces an older
+ * pair of identical dashed-border buttons that read like file-drop zones
+ * and reused the same accent color as the active-session indicator.
+ */
+.footerBtnPrimary {
   flex: 1;
-  padding: 10px;
-  border: 1px dashed var(--border);
+  padding: 11px;
+  border: none;
   border-radius: 8px;
-  background: none;
-  color: var(--accent);
+  background: var(--accent);
+  color: #fff;
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
@@ -291,25 +313,60 @@
   align-items: center;
   justify-content: center;
   gap: 6px;
-  transition: background 0.15s;
+  transition:
+    background 0.15s,
+    transform 0.1s,
+    opacity 0.15s;
   -webkit-tap-highlight-color: transparent;
 }
 
-.footerBtn:hover {
-  background: var(--bg);
+.footerBtnPrimary:hover {
+  background: var(--accent-hover, var(--accent));
+  opacity: 0.94;
 }
 
-.footerBtn:active {
+.footerBtnPrimary:active {
   transform: scale(0.98);
 }
 
-.footerBtn:disabled {
-  opacity: 0.4;
+.footerBtnPrimary:disabled {
+  opacity: 0.5;
   cursor: not-allowed;
 }
 
-.footerBtn:disabled:hover {
-  background: none;
+.footerBtnSecondary {
+  flex: 1;
+  padding: 11px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    transform 0.1s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.footerBtnSecondary:hover {
+  background: var(--surface);
+  border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
+}
+
+.footerBtnSecondary:active {
+  transform: scale(0.98);
+}
+
+.footerBtnSecondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .newBtn {
@@ -330,7 +387,7 @@
 }
 
 .newBtn:hover {
-  background: var(--bg);
+  background: var(--surface);
 }
 
 .newBtn:active {

--- a/src/frontend/src/components/SidePanel/SidePanel.tsx
+++ b/src/frontend/src/components/SidePanel/SidePanel.tsx
@@ -228,16 +228,14 @@ export function SidePanel() {
                       }
                     }}
                   >
-                    {/* Card header: color dot, name, status, close */}
+                    {/* Card header: combined color+status dot, name, close */}
                     <div className={styles.cardHeader}>
-                      <span className={styles.cardDot} style={{ backgroundColor: session.color }} />
-                      <span className={styles.cardName}>{session.name}</span>
-                      {session.id !== activeId && session.hasUnread && (
-                        <span className={styles.unreadDot} />
-                      )}
                       <span
-                        className={styles.cardStatus}
-                        style={{ backgroundColor: statusColor(session) }}
+                        className={styles.cardDot}
+                        style={{
+                          backgroundColor: session.color,
+                          boxShadow: `0 0 0 2px var(--surface), 0 0 0 4px ${statusColor(session)}`,
+                        }}
                         title={
                           session.exited
                             ? 'Exited'
@@ -246,6 +244,10 @@ export function SidePanel() {
                               : 'Disconnected'
                         }
                       />
+                      <span className={styles.cardName}>{session.name}</span>
+                      {session.id !== activeId && session.hasUnread && (
+                        <span className={styles.unreadDot} />
+                      )}
                       <button
                         className={styles.cardClose}
                         onClick={(e) => handleClose(e, session.id)}
@@ -288,7 +290,7 @@ export function SidePanel() {
             <div className={styles.footer}>
               <div className={styles.footerRow}>
                 <button
-                  className={styles.footerBtn}
+                  className={styles.footerBtnPrimary}
                   onClick={() => {
                     openNewSessionModal();
                     animateClose();
@@ -297,7 +299,7 @@ export function SidePanel() {
                   + New Session
                 </button>
                 <button
-                  className={styles.footerBtn}
+                  className={styles.footerBtnSecondary}
                   onClick={() => {
                     useUIStore.getState().openResumeBrowser();
                     animateClose();


### PR DESCRIPTION
Two small UX polish passes for the mobile UI.

SidePanel: panel background now matches the terminal background. The active session uses a single 3px left-edge accent stripe with a neutral border (no more red glow around the row). The session-color and connection-status dots merged into one halo'd dot. "+ New Session" is a filled primary button; "Resume" is a neutral outlined secondary.

Sessions hub: cards play a sequential 3D fold-in cascade after the initial fetch resolves — rotateX from above with top-edge transform-origin and list-level perspective. The arrival window is bounded so the cascade can't overlap a later poll. A skeleton placeholder was tried and removed since the fetch is fast enough that it read as visual noise.

Closes #231