### PR TITLE
feat(hub): replace theme/share/refresh buttons with single Tools button

### DIFF
--- a/src/frontend/src/components/SessionsHub/SessionsHub.module.css
+++ b/src/frontend/src/components/SessionsHub/SessionsHub.module.css
@@ -373,13 +373,3 @@
     padding: 12px 8px;
   }
 }
-
-.refreshSpin {
-  animation: spin 0.6s linear;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}

--- a/src/frontend/src/components/SessionsHub/SessionsHub.tsx
+++ b/src/frontend/src/components/SessionsHub/SessionsHub.tsx
@@ -1,10 +1,13 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { toast } from 'sonner';
-import { fetchSessions, deleteSession, fetchVersion, getShareUrl } from '@/services/api';
+import { fetchSessions, deleteSession, fetchVersion } from '@/services/api';
 import { useUIStore } from '@/stores/uiStore';
 import { useSessionStore } from '@/stores/sessionStore';
 import { useDissolveDelete } from '@/hooks/useDissolveDelete';
 import ThemePicker from '@/components/common/ThemePicker';
+import SettingsPanel from '@/components/SettingsPanel/SettingsPanel';
+import CustomKeysModal from '@/components/CustomKeysModal/CustomKeysModal';
+import ToolsPanel from '@/components/ToolsPanel/ToolsPanel';
 import type { Session } from '@/types';
 import UpdateBanner from '@/components/common/UpdateBanner';
 import TunnelBanner from '@/components/common/TunnelBanner';
@@ -46,38 +49,21 @@ function loadFilterFromStorage(): SessionFilterState {
   }
 }
 
-/* clipboard fallback for non-secure (HTTP) contexts */
-function fallbackCopyShare(text: string): void {
-  const textarea = document.createElement('textarea');
-  textarea.value = text;
-  textarea.style.position = 'fixed';
-  textarea.style.opacity = '0';
-  document.body.appendChild(textarea);
-  textarea.select();
-  try {
-    document.execCommand('copy');
-    toast.success('URL copied to clipboard');
-  } catch {
-    toast.error('Failed to copy URL');
-  }
-  document.body.removeChild(textarea);
-}
-
-const ShareIcon = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <circle cx="18" cy="5" r="3" />
-    <circle cx="6" cy="12" r="3" />
-    <circle cx="18" cy="19" r="3" />
-    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
-    <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
-  </svg>
-);
-
-const RefreshIcon = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <polyline points="23 4 23 10 17 10" />
-    <polyline points="1 20 1 14 7 14" />
-    <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+const ToolsIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="3" y="3" width="7" height="7" rx="1" />
+    <rect x="14" y="3" width="7" height="7" rx="1" />
+    <rect x="3" y="14" width="7" height="7" rx="1" />
+    <rect x="14" y="14" width="7" height="7" rx="1" />
   </svg>
 );
 
@@ -85,7 +71,6 @@ export default function SessionsHub() {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
   const [arriving, setArriving] = useState(false);
-  const [refreshing, setRefreshing] = useState(false);
   const [version, setVersion] = useState('');
   const [revealedId, setRevealedId] = useState<string | null>(null);
   const [filter, setFilter] = useState<SessionFilterState>(() => loadFilterFromStorage());
@@ -96,8 +81,10 @@ export default function SessionsHub() {
     openNewSessionModal,
     openResumeBrowser,
     themePickerOpen,
-    openThemePicker,
     closeThemePicker,
+    toggleToolsPanel,
+    customKeysModalOpen,
+    closeCustomKeysModal,
   } = useUIStore();
 
   const dissolvingIds = useSessionStore((s) => s.dissolvingIds);
@@ -180,9 +167,7 @@ export default function SessionsHub() {
 
   async function handleDelete(id: string) {
     const session = sessions.find((s) => s.id === id);
-    const element = listRef.current?.querySelector<HTMLElement>(
-      `[data-session-id="${id}"]`,
-    );
+    const element = listRef.current?.querySelector<HTMLElement>(`[data-session-id="${id}"]`);
     try {
       await dissolveDelete(id, {
         element: element ?? null,
@@ -211,30 +196,26 @@ export default function SessionsHub() {
     }
   }
 
-  async function handleRefresh() {
-    setRefreshing(true);
-    try {
-      if ('caches' in window && typeof window.caches?.keys === 'function') {
-        const cacheNames = await caches.keys();
-        await Promise.all(cacheNames.map((name) => caches.delete(name)));
+  // Cmd/Ctrl+K toggles the Tools panel — mirrors TerminalApp so the
+  // shortcut is consistent across the app shell. Skip when focus is on a
+  // text field (e.g. the FilterBar input) so the shortcut doesn't hijack
+  // typing inside the search box.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        const target = e.target as HTMLElement | null;
+        const isEditable =
+          target?.tagName === 'INPUT' ||
+          target?.tagName === 'TEXTAREA' ||
+          target?.isContentEditable;
+        if (isEditable) return;
+        e.preventDefault();
+        toggleToolsPanel();
       }
-    } finally {
-      location.reload();
-    }
-  }
-
-  function handleShare() {
-    getShareUrl().then((url) => {
-      if (navigator.clipboard?.writeText) {
-        navigator.clipboard.writeText(url).then(
-          () => toast.success('URL copied to clipboard'),
-          () => fallbackCopyShare(url),
-        );
-      } else {
-        fallbackCopyShare(url);
-      }
-    });
-  }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [toggleToolsPanel]);
 
   return (
     <div className={styles.page}>
@@ -256,48 +237,20 @@ export default function SessionsHub() {
         <div className={styles.headerActions}>
           <button
             className={styles.headerBtn}
-            onClick={openThemePicker}
-            aria-label="Choose theme"
-            title="Theme"
+            onClick={toggleToolsPanel}
+            aria-label="Tools"
+            title="Tools (Ctrl+K)"
+            data-testid="palette-trigger"
           >
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <circle cx="13.5" cy="6.5" r="1.5" fill="currentColor" />
-              <circle cx="17.5" cy="10.5" r="1.5" fill="currentColor" />
-              <circle cx="8.5" cy="7.5" r="1.5" fill="currentColor" />
-              <circle cx="6.5" cy="12.5" r="1.5" fill="currentColor" />
-              <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.83 0 1.5-.67 1.5-1.5 0-.39-.15-.74-.39-1.01-.23-.26-.38-.61-.38-.99 0-.83.67-1.5 1.5-1.5H16c3.31 0 6-2.69 6-6 0-5.52-4.48-10-10-10z" />
-            </svg>
-          </button>
-          <button
-            className={styles.headerBtn}
-            onClick={handleShare}
-            aria-label="Share URL"
-            title="Share"
-          >
-            <ShareIcon />
-          </button>
-          <button
-            className={styles.headerBtn}
-            onClick={handleRefresh}
-            aria-label="Refresh sessions"
-            title="Refresh"
-            data-testid="hub-refresh-btn"
-          >
-            <span className={refreshing ? styles.refreshSpin : ''} style={{ display: 'flex' }}>
-              <RefreshIcon />
-            </span>
+            <ToolsIcon />
           </button>
         </div>
       </header>
 
       <ThemePicker open={themePickerOpen} onClose={closeThemePicker} hideTrigger />
+      <ToolsPanel inHub />
+      <SettingsPanel inHub />
+      <CustomKeysModal open={customKeysModalOpen} onClose={closeCustomKeysModal} />
 
       <main className={styles.content} aria-busy={loading || undefined}>
         {loading ? null : sessions.length === 0 ? (

--- a/src/frontend/src/components/SettingsPanel/SettingsPanel.tsx
+++ b/src/frontend/src/components/SettingsPanel/SettingsPanel.tsx
@@ -46,7 +46,19 @@ function truncateCmd(cmd: string, max = 36): string {
   return `${cmd.slice(0, max - 1).trimEnd()}…`;
 }
 
-export default function SettingsPanel() {
+interface SettingsPanelProps {
+  /**
+   * Set when the panel is rendered from the Sessions hub (no active terminal
+   * session). Hides actions that depend on the live session store
+   * (`Save current as new workspace`, per-workspace `Update`) because the
+   * global session store is not authoritative on the Hub — the Hub maintains
+   * its own polled list. Without this, "Update" on an existing workspace
+   * could clobber it with stale leftovers from a prior terminal visit.
+   */
+  inHub?: boolean;
+}
+
+export default function SettingsPanel({ inHub = false }: SettingsPanelProps = {}) {
   const open = useUIStore((s) => s.settingsPanelOpen);
   const close = useUIStore((s) => s.closeSettingsPanel);
   const openThemePicker = useUIStore((s) => s.openThemePicker);
@@ -443,8 +455,8 @@ export default function SettingsPanel() {
               <span className={styles.rowLabel}>
                 Particle dissolve
                 <span className={styles.rowHint}>
-                  Play the canvas particle effect when deleting a session. Turn off for a plain
-                  fade only — useful on low-power devices.
+                  Play the canvas particle effect when deleting a session. Turn off for a plain fade
+                  only — useful on low-power devices.
                 </span>
               </span>
               <Toggle
@@ -462,7 +474,9 @@ export default function SettingsPanel() {
             <div className={styles.row}>
               <span className={styles.rowLabel}>
                 Start collapsed
-                <span className={styles.rowHint}>Hide TouchBar by default; tap the handle to expand</span>
+                <span className={styles.rowHint}>
+                  Hide TouchBar by default; tap the handle to expand
+                </span>
               </span>
               <Toggle
                 on={prefs.touchBarCollapsed}
@@ -558,7 +572,7 @@ export default function SettingsPanel() {
 
               return (
                 <>
-                  {!fullyEmpty && (
+                  {!fullyEmpty && !inHub && (
                     <div className={styles.workspaceSaveRow}>
                       <button
                         type="button"
@@ -578,16 +592,24 @@ export default function SettingsPanel() {
                       </div>
                       <div className={styles.workspaceEmptyTitle}>No workspaces yet</div>
                       <p className={styles.workspaceEmptyDesc}>
-                        Save groups of sessions to launch them together. Open some sessions, then
-                        click <strong>Save current as new workspace</strong>.
+                        {inHub
+                          ? 'Save groups of sessions to launch them together. Open a session, then come back here to capture it.'
+                          : 'Save groups of sessions to launch them together. Open some sessions, then click '}
+                        {!inHub && (
+                          <>
+                            <strong>Save current as new workspace</strong>.
+                          </>
+                        )}
                       </p>
-                      <button
-                        type="button"
-                        className={styles.workspaceEmptyCta}
-                        onClick={saveAsNewWorkspace}
-                      >
-                        Save current as new workspace
-                      </button>
+                      {!inHub && (
+                        <button
+                          type="button"
+                          className={styles.workspaceEmptyCta}
+                          onClick={saveAsNewWorkspace}
+                        >
+                          Save current as new workspace
+                        </button>
+                      )}
                       {saveToast && (
                         <span className={styles.saveToastChip} style={{ marginTop: 10 }}>
                           {saveToast}
@@ -610,16 +632,16 @@ export default function SettingsPanel() {
                               <div className={styles.workspaceCardTitle}>
                                 <span className={styles.workspaceCardName}>{ws.name}</span>
                                 {ws.default && (
-                                  <span className={styles.workspaceAutoStartChip}>
-                                    Auto-start
-                                  </span>
+                                  <span className={styles.workspaceAutoStartChip}>Auto-start</span>
                                 )}
                               </div>
                             </div>
                             <div className={styles.workspaceCardSummary}>
                               {ws.sessions.length} session{ws.sessions.length === 1 ? '' : 's'}
-                              {shellCount > 0 && ` · ${shellCount} terminal${shellCount === 1 ? '' : 's'}`}
-                              {agentCount > 0 && ` · ${agentCount} agent${agentCount === 1 ? '' : 's'}`}
+                              {shellCount > 0 &&
+                                ` · ${shellCount} terminal${shellCount === 1 ? '' : 's'}`}
+                              {agentCount > 0 &&
+                                ` · ${agentCount} agent${agentCount === 1 ? '' : 's'}`}
                             </div>
 
                             {ws.sessions.length === 0 ? (
@@ -646,10 +668,7 @@ export default function SettingsPanel() {
                                         </code>
                                       )}
                                       {s.cwd && (
-                                        <span
-                                          className={styles.workspaceMiniCwd}
-                                          title={s.cwd}
-                                        >
+                                        <span className={styles.workspaceMiniCwd} title={s.cwd}>
                                           {cwdLeaf(s.cwd)}
                                         </span>
                                       )}
@@ -669,14 +688,16 @@ export default function SettingsPanel() {
                                 <span>Launch on TermBeam start</span>
                               </label>
                               <div className={styles.workspaceCardActions}>
-                                <button
-                                  type="button"
-                                  className={styles.linkBtn}
-                                  onClick={() => updateWorkspaceFromCurrent(ws.id)}
-                                  title="Replace this workspace with the currently open sessions"
-                                >
-                                  Update
-                                </button>
+                                {!inHub && (
+                                  <button
+                                    type="button"
+                                    className={styles.linkBtn}
+                                    onClick={() => updateWorkspaceFromCurrent(ws.id)}
+                                    title="Replace this workspace with the currently open sessions"
+                                  >
+                                    Update
+                                  </button>
+                                )}
                                 <button
                                   type="button"
                                   className={styles.linkBtn}
@@ -707,15 +728,21 @@ export default function SettingsPanel() {
                         Restore default startup
                         <span className={styles.rowHint}>
                           {prefs.startupWorkspace.sessions.length} session
-                          {prefs.startupWorkspace.sessions.length === 1 ? '' : 's'} (legacy) ·{' '}
-                          <button
-                            type="button"
-                            className={styles.linkBtn}
-                            onClick={saveWorkspace}
-                            style={{ padding: 0, fontSize: '0.75rem' }}
-                          >
-                            update from current
-                          </button>
+                          {prefs.startupWorkspace.sessions.length === 1 ? '' : 's'} (legacy)
+                          {!inHub && (
+                            <>
+                              {' '}
+                              ·{' '}
+                              <button
+                                type="button"
+                                className={styles.linkBtn}
+                                onClick={saveWorkspace}
+                                style={{ padding: 0, fontSize: '0.75rem' }}
+                              >
+                                update from current
+                              </button>
+                            </>
+                          )}
                         </span>
                       </span>
                       <Toggle
@@ -741,9 +768,7 @@ export default function SettingsPanel() {
               type="button"
               className={styles.linkBtn}
               onClick={() => {
-                if (
-                  confirm('Reset all preferences to defaults? This will sync to the server.')
-                ) {
+                if (confirm('Reset all preferences to defaults? This will sync to the server.')) {
                   Object.entries(PREF_DEFAULTS).forEach(([k, v]) => {
                     setPreference(k as keyof typeof PREF_DEFAULTS, v as never);
                   });

--- a/src/frontend/src/components/ToolsPanel/ToolsPanel.tsx
+++ b/src/frontend/src/components/ToolsPanel/ToolsPanel.tsx
@@ -345,7 +345,6 @@ const iconSettings = (
   </svg>
 );
 
-
 /* ---------- clipboard fallback for non-secure (HTTP) contexts ---------- */
 
 function fallbackCopy(text: string): void {
@@ -366,7 +365,7 @@ function fallbackCopy(text: string): void {
 
 /* ---------- component ---------- */
 
-export default function ToolsPanel() {
+export default function ToolsPanel({ inHub = false }: { inHub?: boolean } = {}) {
   const open = useUIStore((s) => s.toolsPanelOpen);
   const closeAction = useUIStore((s) => s.closeToolsPanel);
   const [aboutOpen, setAboutOpen] = useState(false);
@@ -461,10 +460,12 @@ export default function ToolsPanel() {
   /* ---- section definitions ---- */
 
   type Action = { id: string; label: string; icon: React.ReactNode; action: () => void };
-  type Section = { title: string; actions: Action[] };
+  type SectionId = 'session' | 'files' | 'view' | 'share' | 'agents' | 'settings' | 'system';
+  type Section = { id: SectionId; title: string; actions: Action[] };
 
-  const sections: Section[] = [
+  const allSections: Section[] = [
     {
+      id: 'session',
       title: 'SESSION',
       actions: [
         {
@@ -500,6 +501,7 @@ export default function ToolsPanel() {
       ],
     },
     {
+      id: 'files',
       title: 'FILES',
       actions: [
         {
@@ -536,6 +538,7 @@ export default function ToolsPanel() {
       ],
     },
     {
+      id: 'view',
       title: 'VIEW',
       actions: [
         {
@@ -593,6 +596,7 @@ export default function ToolsPanel() {
       ],
     },
     {
+      id: 'share',
       title: 'SHARE',
       actions: [
         {
@@ -628,6 +632,7 @@ export default function ToolsPanel() {
       ],
     },
     {
+      id: 'agents',
       title: 'AGENTS',
       actions: [
         {
@@ -645,6 +650,7 @@ export default function ToolsPanel() {
       ],
     },
     {
+      id: 'settings',
       title: 'SETTINGS',
       actions: [
         {
@@ -656,6 +662,7 @@ export default function ToolsPanel() {
       ],
     },
     {
+      id: 'system',
       title: 'SYSTEM',
       actions: [
         {
@@ -692,12 +699,28 @@ export default function ToolsPanel() {
     },
   ];
 
+  // On the Hub there is no active terminal session, so:
+  //   - Hide SESSION + FILES entirely (every action depends on activeId).
+  //   - Keep VIEW with no action buttons but render the ThemePicker — theme
+  //     is a global preference that's useful on the Hub.
+  //   - Keep SHARE, AGENTS, SETTINGS as-is (universal actions).
+  //   - Keep SYSTEM minus 'Clear terminal' (no terminal to clear).
+  // Filter by stable section IDs so display titles can change without
+  // breaking this logic.
+  const sections: Section[] = inHub
+    ? allSections
+        .filter((s) => s.id !== 'session' && s.id !== 'files')
+        .map((s) => {
+          if (s.id === 'view') return { ...s, actions: [] };
+          if (s.id === 'system')
+            return { ...s, actions: s.actions.filter((a) => a.id !== 'clear') };
+          return s;
+        })
+    : allSections;
+
   return (
     <>
-      <div
-        className={`${styles.backdrop} ${mounted ? styles.backdropOpen : ''}`}
-        onClick={close}
-      />
+      <div className={`${styles.backdrop} ${mounted ? styles.backdropOpen : ''}`} onClick={close} />
       <div className={panelCls} data-testid="palette-panel" data-open="true">
         <div className={styles.header}>
           <span className={styles.title}>Tools</span>
@@ -707,7 +730,7 @@ export default function ToolsPanel() {
         </div>
         <div className={styles.body}>
           {sections.map((sec) => (
-            <div key={sec.title} className={styles.section}>
+            <div key={sec.id} className={styles.section}>
               <div className={styles.sectionTitle}>{sec.title}</div>
               {sec.actions.map((a) => (
                 <button
@@ -720,7 +743,7 @@ export default function ToolsPanel() {
                   {a.label}
                 </button>
               ))}
-              {sec.title === 'VIEW' && (
+              {sec.id === 'view' && (
                 <div className={styles.themePickerRow}>
                   <ThemePicker onSelect={() => close()} />
                 </div>

--- a/test/e2e-features.test.js
+++ b/test/e2e-features.test.js
@@ -570,9 +570,25 @@ test.describe('Hub Page', () => {
 
     // Functional check: clicking Settings… opens the SettingsPanel
     await panel.getByText('Settings…', { exact: true }).click();
-    await expect(page.getByRole('dialog', { name: 'Settings' })).toBeVisible({
+    const settingsDialog = page.getByRole('dialog', { name: 'Settings' });
+    await expect(settingsDialog).toBeVisible({
       timeout: 3_000,
     });
+
+    // Hub-mode SettingsPanel must hide actions that snapshot the live
+    // session store — see the `inHub` prop on SettingsPanel. Without this
+    // guard, "Save current as new workspace" / per-workspace "Update" /
+    // legacy "update from current" could clobber a saved workspace with
+    // stale leftovers from a prior terminal visit.
+    await expect(
+      settingsDialog.getByRole('button', { name: /Save current as new workspace/i }),
+    ).toHaveCount(0);
+    await expect(settingsDialog.getByRole('button', { name: 'Update', exact: true })).toHaveCount(
+      0,
+    );
+    await expect(
+      settingsDialog.getByRole('button', { name: 'update from current', exact: true }),
+    ).toHaveCount(0);
   });
 
   test('connect button on session card navigates to terminal', async ({ page }) => {

--- a/test/e2e-features.test.js
+++ b/test/e2e-features.test.js
@@ -539,21 +539,39 @@ test.describe('Hub Page', () => {
     expect(versionText).toMatch(/v?\d+\.\d+/);
   });
 
-  test('refresh button reloads session list', async ({ page }) => {
-    await createSessionViaAPI();
+  test('tools button opens tools panel with hub-relevant actions', async ({ page }) => {
     await navigateToHub(page);
 
-    // Session list should have sessions (auto-created + API-created)
-    await expect(page.locator('[data-testid="session-card"]')).toHaveCount(2, {
-      timeout: 5_000,
-    });
+    // Panel should not exist initially
+    await expect(page.locator('[data-testid="palette-panel"][data-open="true"]')).toHaveCount(0);
 
-    // Click refresh
-    await page.click('[data-testid="hub-refresh-btn"]');
+    // Open via the new Tools button in the header (same testid as terminal)
+    await page.click('[data-testid="palette-trigger"]');
+    const panel = page.locator('[data-testid="palette-panel"][data-open="true"]');
+    await expect(panel).toBeVisible({ timeout: 3_000 });
 
-    // Sessions should still be listed after refresh
-    await expect(page.locator('[data-testid="session-card"]')).toHaveCount(2, {
-      timeout: 5_000,
+    // Hub-relevant actions should be present
+    await expect(panel.getByText('Copy link', { exact: true })).toBeVisible();
+    await expect(panel.getByText('Launch agent', { exact: true })).toBeVisible();
+    await expect(panel.getByText('Resume agent session', { exact: true })).toBeVisible();
+    await expect(panel.getByText('Settings…', { exact: true })).toBeVisible();
+    await expect(panel.getByText('Refresh', { exact: true })).toBeVisible();
+    await expect(panel.getByText('About', { exact: true })).toBeVisible();
+
+    // Theme picker is mounted under the VIEW section (the section's
+    // action buttons are filtered out on the Hub but the picker stays).
+    await expect(panel.locator('[data-testid="theme-trigger"]')).toBeVisible();
+
+    // Session-specific actions should be hidden
+    await expect(panel.getByText('Browse files', { exact: true })).toHaveCount(0);
+    await expect(panel.getByText('Clear terminal', { exact: true })).toHaveCount(0);
+    await expect(panel.getByText('New tab', { exact: true })).toHaveCount(0);
+    await expect(panel.getByText('Increase font size', { exact: true })).toHaveCount(0);
+
+    // Functional check: clicking Settings… opens the SettingsPanel
+    await panel.getByText('Settings…', { exact: true }).click();
+    await expect(page.getByRole('dialog', { name: 'Settings' })).toBeVisible({
+      timeout: 3_000,
     });
   });
 


### PR DESCRIPTION
Consolidates the three SessionsHub header buttons (theme, share, refresh) into a single Tools button that opens the existing ToolsPanel — same one the terminal uses with Cmd/Ctrl+K. On the Hub the panel is filtered (new `inHub` prop): SESSION and FILES are hidden, VIEW keeps only the inline theme picker, AGENTS/SHARE/SETTINGS/SYSTEM stay, Clear terminal is dropped. Cmd/Ctrl+K toggles Tools on the Hub too, with an editable-target guard so the FilterBar search input isn't hijacked.

SettingsPanel gains an `inHub` prop that hides workspace actions which would otherwise snapshot a stale global session store from the Hub ("Save current as new workspace", per-workspace "Update", legacy "update from current").

Closes #233