### PR TITLE
fix(release): add NPM_TOKEN fallback for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,12 +118,20 @@ jobs:
           fi
           git push origin main --follow-tags
 
+      # npm auth: primary path is npm Trusted Publishing via OIDC (requires
+      # `id-token: write` above + a Trusted Publisher configured on npmjs.com
+      # for this repo + workflow path). NODE_AUTH_TOKEN is a fallback for forks
+      # or environments where Trusted Publishing is not configured.
       - name: Publish to npm
         if: inputs.dry-run == false
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public --provenance
 
       - name: Publish to npm (dry run)
         if: inputs.dry-run == true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public --provenance --dry-run
 
       - name: Create GitHub Release


### PR DESCRIPTION
Addresses Copilot review comment on #239: `npm publish` had no explicit auth fallback. Past releases worked via npm Trusted Publishing (OIDC), confirmed by provenance attestations on published tarballs (e.g. termbeam@1.24.6 has `predicateType: https://slsa.dev/provenance/v1`). Adds `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` as a fallback so releases stay reliable if Trusted Publishing is disabled or run from a fork. Documents the dual auth model with a header comment.