### PR TITLE
ci(combine-prs): support optional PAT to trigger downstream CI

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -32,6 +32,15 @@ name: Combine Dependabot PRs
 #   never checks out PR-supplied code. It only invokes `gh` + `git` on
 #   PR refs to merge their commits into our branch. No PR-controlled
 #   script executes here.
+#
+# Token note:
+#   PRs created with the default `GITHUB_TOKEN` do NOT trigger downstream
+#   workflow runs (GitHub anti-recursion). To get CI to start on the
+#   combined PR automatically, add a fine-grained PAT as repository secret
+#   `COMBINE_PRS_TOKEN` (scopes: contents:write, pull-requests:write).
+#   Without that secret the workflow still falls back to `GITHUB_TOKEN`,
+#   the combined PR will be created, but you'll have to close+reopen it
+#   once to kick CI.
 on:
   pull_request_target:
     types: [opened, reopened, ready_for_review, labeled]
@@ -74,7 +83,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.COMBINE_PRS_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Configure git
         run: |
@@ -83,7 +92,7 @@ jobs:
 
       - name: Combine open Dependabot PRs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.COMBINE_PRS_TOKEN || secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ inputs.dry-run }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
PRs created by the default `GITHUB_TOKEN` don't fire `pull_request` events (GitHub anti-recursion), so consolidated PRs sit with no CI until someone close+reopens them.

This PR wires `combine-prs.yml` to prefer `secrets.COMBINE_PRS_TOKEN` (fine-grained PAT, scopes: `contents:write` + `pull-requests:write` on this repo) when present, falling back to `GITHUB_TOKEN`.

## After merge — one-time setup

1. Create a **fine-grained PAT** at https://github.com/settings/personal-access-tokens/new
   - Resource owner: `dorlugasigal`
   - Repository access: only `TermBeam`
   - Permissions: **Contents: Read and write**, **Pull requests: Read and write**
   - Expiration: whatever fits your policy
2. Add it as a repo secret: `gh secret set COMBINE_PRS_TOKEN --repo dorlugasigal/TermBeam --body '<paste-token>'`
3. Done — next Dependabot wave will auto-create the combined PR **and** start CI on it.

If the secret is not set, behavior is unchanged (combined PR is created, but CI needs a manual close+reopen kick).

## What changed
- `combine-prs.yml` checkout `token:` and step `GH_TOKEN` env now read `secrets.COMBINE_PRS_TOKEN || secrets.GITHUB_TOKEN`
- Header comment documents the why + how-to-enable