### PR TITLE
feat(ci): auto patch-release after Dependabot merges

### DIFF
--- a/.github/workflows/dependabot-release.yml
+++ b/.github/workflows/dependabot-release.yml
@@ -35,8 +35,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_MSG: ${{ github.event.head_commit.message }}
         run: |
-          # Squash-merge subjects end with "(#N)". Extract the PR number.
-          PR=$(printf '%s\n' "$HEAD_MSG" | head -1 | grep -oE '\(#[0-9]+\)' | tail -1 | tr -dc '0-9')
+          # Extract the PR number from the merge subject. Handles squash subjects
+          # ("... (#N)") and merge-commit subjects ("Merge pull request #N from ...").
+          PR=$(printf '%s\n' "$HEAD_MSG" | head -1 | grep -oE '#[0-9]+' | tail -1 | tr -dc '0-9')
           if [ -z "$PR" ]; then
             echo "No PR reference in head commit; not a merge."
             echo "is_dependabot=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dependabot-release.yml
+++ b/.github/workflows/dependabot-release.yml
@@ -1,0 +1,76 @@
+# Auto-publishes a single patch release after Dependabot dependency PRs merge to main.
+#
+# Grouped/burst merges are batched: each new Dependabot merge cancels the pending
+# debounce timer and starts a fresh 30-minute quiet window, so a run of grouped PRs
+# results in exactly ONE patch release covering all of them.
+#
+# Only Dependabot dependency merges trigger this. Your own feature/fix merges are
+# released manually via the publish workflow with a chosen bump.
+name: Dependabot Auto Patch Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  # Runs on every push. Decides whether HEAD is a Dependabot dependency merge.
+  # Kept separate from the debounce job so that a non-Dependabot push never enters
+  # the shared concurrency group and cancels a pending release.
+  detect:
+    runs-on: ubuntu-latest
+    # Skip the release bot's own commits to avoid any chance of a loop.
+    if: >-
+      !startsWith(github.event.head_commit.message, 'chore(release)') &&
+      !contains(github.event.head_commit.message, '[skip ci]')
+    permissions:
+      pull-requests: read
+    outputs:
+      is_dependabot: ${{ steps.check.outputs.is_dependabot }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          # Squash-merge subjects end with "(#N)". Extract the PR number.
+          PR=$(printf '%s\n' "$HEAD_MSG" | head -1 | grep -oE '\(#[0-9]+\)' | tail -1 | tr -dc '0-9')
+          if [ -z "$PR" ]; then
+            echo "No PR reference in head commit; not a merge."
+            echo "is_dependabot=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          AUTHOR=$(gh pr view "$PR" -R "$GITHUB_REPOSITORY" --json author --jq '.author.login' 2>/dev/null || echo "")
+          echo "PR #$PR author: ${AUTHOR:-<unknown>}"
+          if [ "$AUTHOR" = "app/dependabot" ] || [ "$AUTHOR" = "dependabot" ] || [ "$AUTHOR" = "dependabot[bot]" ]; then
+            echo "is_dependabot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_dependabot=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Debounce window. A newer Dependabot merge cancels this run (cancel-in-progress)
+  # and restarts the timer, so bursts collapse into one release.
+  debounce-release:
+    needs: detect
+    if: needs.detect.outputs.is_dependabot == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: dependabot-auto-patch-release
+      cancel-in-progress: true
+    permissions:
+      actions: write
+    steps:
+      - name: Wait for grouped merges to settle
+        run: |
+          echo "Debouncing for 30 minutes; a newer Dependabot merge will restart this."
+          sleep 1800
+
+      - name: Dispatch patch release
+        env:
+          # PAT so the dispatched release run isn't suppressed and can push the tag/commit.
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          echo "Quiet window elapsed. Dispatching patch release."
+          gh workflow run release.yml -R "$GITHUB_REPOSITORY" -f bump=patch -f dry-run=false


### PR DESCRIPTION
Automates the last manual step in our Dependabot pipeline: publishing a patch to npm after dependency PRs merge.

When a Dependabot dependency PR merges to `main`, this starts a 30-minute quiet window. Any further Dependabot merge cancels the pending timer and restarts it (via `concurrency: cancel-in-progress`), so a burst of grouped PRs collapses into **one** patch release covering all of them. Once merges settle it dispatches `release.yml` with `bump=patch`. Only Dependabot dependency merges trigger it — your own feature/fix releases stay manual. The release commit is `[skip ci]`, so there's no loop.

```mermaid
flowchart TD
    A[Dependabot PR merges to main] --> B{HEAD is Dependabot merge?}
    B -- no --> Z[do nothing]
    B -- yes --> C[Start 30-min quiet window]
    D[Another Dependabot merge] -->|cancel-in-progress| C
    C --> E{Window elapsed without a newer merge?}
    E -- no, restarted --> C
    E -- yes --> F[Dispatch release.yml bump=patch]
    F --> G[npm publish + GitHub Release]
```

Closes #267
